### PR TITLE
Detection of existence of key 'PATH' in os.environ

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1105,7 +1105,10 @@ if __name__ == '__main__':
     exitcode = 0
 
     info(3, 'sysname=%s, platform=%s, python=%s, python-version=%s' % (os.name, sys.platform, sys.executable, sys.version))
-
+    
+    if "PATH" not in os.environ:
+        os.environ['PATH'] = ""
+    
     for of in find_offices():
         if of.python != sys.executable and not sys.executable.startswith(of.basepath):
             python_switch(of)


### PR DESCRIPTION
As evidenced by @simkimsia, running unoconv through nginx/php has reason to fail
 * This appears to be due to nginx not setting/including the PATH environment variable
 * Thus when unoconv attempts to read os.environ['PATH'], it can't because the key doesn't exist, causing a fatal error

The changes in this pull request remedy the problem by detecting if os.environ has the key 'PATH' and creating it if it does not.