### PR TITLE
set format based on extension

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -655,6 +655,8 @@ class Options:
             l = sys.argv[0].split('2')
             if len(l) == 2:
                 self.format = l[1]
+            elif self.output and self.output.find('.') >= 0:
+                self.format = os.path.splitext(self.output)[1].replace('.', '')
             else:
                 self.format = 'pdf'
 


### PR DESCRIPTION
There appears to be a bug where if you set the output file with extension and give an input file, the output file will be generated only as a pdf.  This is a quick fix to get it working, but don't know the script very well, so perhaps there's a better place to add this fix.