### PR TITLE
Fix python2 compatibility after 3249fd3

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1145,7 +1145,10 @@ if __name__ == '__main__':
             self.closed = 1
 
         def writeBytes( self, seq ):
-            sys.stdout.buffer.write( seq.value )
+            try:
+                sys.stdout.buffer.write( seq.value )
+            except AttributeError:
+                sys.stdout.write( seq.value )
 
         def flush( self ):
             pass


### PR DESCRIPTION
It would be nice to cut a 0.7 after this, a working python3 release is long due. Thanks