### PR TITLE
Add -F|--field to update user-defined fields before exporting document

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -876,8 +876,13 @@ class Convertor:
             ### Replace variables
             phase = "replace-fields"
             for f in op.fields:
-              field = document.TextFieldMasters.getByName("com.sun.star.text.fieldmaster.SetExpression.%s" % f)
-              field.DependentTextFields[0].setPropertyValue('Content', op.fields[f])
+              try:
+                field = document.TextFieldMasters.getByName("com.sun.star.text.fieldmaster.SetExpression.%s" % f)
+                field.DependentTextFields[0].setPropertyValue('Content', op.fields[f])
+              except UnoException:
+                print("unoconv: failed to replace variable '%s' with value '%s' in the document." % (f, op.fields[f]))
+                pass
+                
 
             ### Update document indexes
             phase = "update-indexes"

--- a/unoconv
+++ b/unoconv
@@ -509,6 +509,7 @@ class Options:
         self.doctype = None
         self.exportfilter = []
         self.exportfilteroptions = ""
+        self.fields = {}
         self.filenames = []
         self.format = None
         self.importfilter = []
@@ -528,8 +529,8 @@ class Options:
 
         ### Get options from the commandline
         try:
-            opts, args = getopt.getopt (args, 'c:Dd:e:f:hi:Llo:np:s:T:t:vV',
-                ['connection=', 'debug', 'doctype=', 'export=', 'format=',
+            opts, args = getopt.getopt (args, 'c:Dd:e:F:f:hi:Llo:np:s:T:t:vV',
+                ['connection=', 'debug', 'doctype=', 'export=', 'field=', 'format=',
                  'help', 'import', 'listener', 'no-launch', 'output=',
                  'outputpath', 'password=', 'pipe=', 'port=', 'server=',
                  'timeout=', 'show', 'stdout', 'template', 'verbose',
@@ -567,6 +568,9 @@ class Options:
                             self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
                 else:
                     print('Warning: Option %s cannot be parsed, ignoring.' % arg, file=sys.stderr)
+            elif opt in ['-F', '--field']:
+                l = arg.split('=')
+                self.fields[l[0]] = l[1]
             elif opt in ['-f', '--format']:
                 self.format = arg
             elif opt in ['-i', '--import']:
@@ -868,6 +872,12 @@ class Convertor:
             except AttributeError:
                 # the document doesn't implement the XLinkUpdate interface
                 pass
+
+            ### Replace variables
+            phase = "replace-fields"
+            for f in op.fields:
+              field = document.TextFieldMasters.getByName("com.sun.star.text.fieldmaster.SetExpression.%s" % f)
+              field.DependentTextFields[0].setPropertyValue('Content', op.fields[f])
 
             ### Update document indexes
             phase = "update-indexes"

--- a/unoconv
+++ b/unoconv
@@ -690,6 +690,8 @@ unoconv options:
   -e, --export=name=value  set export filter options
                              eg. -e PageRange=1-2
   -f, --format=format      specify the output format
+  -F, --field=name=value   replace user-defined text field with value
+                             eg. -F Client_Name="Oracle"
   -i, --import=string      set import filter option string
                              eg. -i utf8
   -l, --listener           start a permanent listener to use by unoconv clients


### PR DESCRIPTION
This PR adds a new option to update user defined fields before exporting the document, e.g.:

    $ unoconv -f pdf -F Client_Name="Advanced Augeas" -F Document_Type="Student Guide" -F Document_Title="for Systems Administrators" -F Document_Date="`date --iso`" -F Document_Last_Version="2.1" augeas_cover.odt 