### PR TITLE
Make output to a specified dir work for multiple input files

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -920,7 +920,7 @@ class Convertor:
                 if not op.output:
                     outputfn = outputfn + os.extsep + outputfmt.extension
                 elif len(op.filenames) > 1:
-                    outputfn = op.output + os.extsep + outputfmt.extension
+                    outputfn = op.output + outputfn + os.extsep + outputfmt.extension
                 else:
                     outputfn = realpath(op.output, os.path.basename(outputfn) + os.extsep + outputfmt.extension)
 


### PR DESCRIPTION
I was trying to convert multiple files, with their outputs landing in a different directory.

Prior to this patch, they would end up in the output dir, but without a filename (just an extension) which effectively made them overwrite each other as hidden dotfiles.

Ex. unoconv --output=temp/ -f pdf doc1.doc doc2.doc

While this doesn't help people operating on single inputs (like in issue #133) I believe it is a good fix for anyone mixing the output flag with multiple inputs!