### PR TITLE
Add a extra search path on MacOS X for OpenOffice

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -90,6 +90,7 @@ def find_offices():
         elif os.name in ( 'mac', ) or sys.platform in ( 'darwin', ):
             extrapaths += [ '/Applications/LibreOffice.app/Contents',
                             '/Applications/NeoOffice.app/Contents',
+                            '/Applications/OpenOffice.app/Contents',
                             '/Applications/OpenOffice.org.app/Contents' ]
 
         else:


### PR DESCRIPTION
OpenOffice 4.1 installs under /Applications/OpenOffice.app/ rather
than /Applications/OpenOffice.org.app/.