### PR TITLE
Add extra bin/lib directories for LibreOffice on OS X

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -125,12 +125,17 @@ def find_offices():
         libpath = 'error'
         for basis in ( 'basis-link', 'basis', '' ):
             for lib in officelibraries:
-                if os.path.isfile(realpath(basepath, basis, 'program', lib)):
-                    libpath = realpath(basepath, basis, 'program')
-                    officelibrary = realpath(libpath, lib)
-                    info(3, "Found %s in %s" % (lib, libpath))
-                    # Break the inner loop...
-                    break
+                for libdir in ( 'program', 'Frameworks' ):
+                    if os.path.isfile(realpath(basepath, basis, libdir, lib)):
+                        libpath = realpath(basepath, basis, libdir)
+                        officelibrary = realpath(libpath, lib)
+                        info(3, "Found %s in %s" % (lib, libpath))
+                        # Break the inner loop...
+                        break
+                # Continue if the inner loop wasn't broken.
+                else:
+                    continue
+                break
             # Continue if the inner loop wasn't broken.
             else:
                 continue
@@ -143,12 +148,17 @@ def find_offices():
         unopath = 'error'
         for basis in ( 'basis-link', 'basis', '' ):
             for bin in officebinaries:
-                if os.path.isfile(realpath(basepath, basis, 'program', bin)):
-                    unopath = realpath(basepath, basis, 'program')
-                    officebinary = realpath(unopath, bin)
-                    info(3, "Found %s in %s" % (bin, unopath))
-                    # Break the inner loop...
-                    break
+                for bindir in ( 'program', 'MacOS' ):
+                    if os.path.isfile(realpath(basepath, basis, bindir, bin)):
+                        unopath = realpath(basepath, basis, bindir)
+                        officebinary = realpath(unopath, bin)
+                        info(3, "Found %s in %s" % (bin, unopath))
+                        # Break the inner loop...
+                        break
+                # Continue if the inner loop wasn't broken.
+                else:
+                    continue
+                break
             # Continue if the inner loop wasn't broken.
             else:
                 continue
@@ -930,9 +940,9 @@ class Convertor:
             phase = "update-links"
             try:
                 document.updateLinks()
-                # Found that when converting HTML files with external images, OO would only load five or six of 
-                # the images in the file. In the resulting document, the rest of the images did not appear. Cycling 
-                # through all the image references in the document seems to force OO to actually load them. Found 
+                # Found that when converting HTML files with external images, OO would only load five or six of
+                # the images in the file. In the resulting document, the rest of the images did not appear. Cycling
+                # through all the image references in the document seems to force OO to actually load them. Found
                 # some helpful guidance in this thread:
                 # https://forum.openoffice.org/en/forum/viewtopic.php?f=30&t=23909
                 # Ideally we would like to have the option to embed the images into the document, but I have not been


### PR DESCRIPTION
In LibreOffice 4.4.3.2 on OS X, the library files are in `/Applications/LibreOffice.app/Contents/Frameworks/` and the binary files are in `/Applications/LibreOffice.app/Contents/MacOS/`. With this change, the `Frameworks` and `MacOS` directories are checked as well as `program`.