### PR TITLE
Add spreadsheet related option, support inter-process kill signal, and auto clean option

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -542,7 +542,7 @@ class Options:
         self.splitspreadsheet = False
         self.splitspreadsheetqueue = None
         self.spreadsheetidx = None
-        self.spreadsheetfitpage = False
+        self.spreadsheetfitpage = None
 
         ### Get options from the commandline
         try:
@@ -553,7 +553,7 @@ class Options:
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
                  'verbose', 'version',
                  'autoreset',
-                 'spreadsheet-split', 'spreadsheet-idx=', 'spreadsheet-fitpage'] )
+                 'spreadsheet-split', 'spreadsheet-idx=', 'spreadsheet-fitpage='] )
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
@@ -662,7 +662,8 @@ class Options:
             elif opt in ['--spreadsheet-split']:
                 self.splitspreadsheet = True
             elif opt in ['--spreadsheet-fitpage']:
-                self.spreadsheetfitpage = True
+                if arg in ['x', 'y', 'all']:
+                    self.spreadsheetfitpage = arg
             elif opt in ['--spreadsheet-idx']:
                 self.spreadsheetidx = int(arg)
 
@@ -769,7 +770,8 @@ unoconv options:
       --autoreset                     reset libreoffice for each file
       --spreadsheet-split             split worksheets in spreadsheet
       --spreadsheet-idx=idx           specify spreadsheet idx
-      --spreadsheet-fitpage           worksheet fit page
+      --spreadsheet-fitpage=type      worksheet fit page (x, y, all)
+                                        eg. --spreadsheet-fitpage=all
 ''', file=sys.stderr)
 
 class Convertor:
@@ -965,8 +967,13 @@ class Convertor:
                     document = self.split_spreadsheet(document, op.splitspreadsheetqueue[0])
                     self.set_pagestyle(document, 'FooterIsOn', False)
 
-                if op.spreadsheetfitpage:
-                    self.set_pagestyle(document, 'ScaleToPages', 1)
+                if op.spreadsheetfitpage != None:
+                    if op.spreadsheetfitpage == 'x':
+                        self.set_pagestyle(document, 'ScaleToPagesX', 1)
+                    elif op.spreadsheetfitpage == 'y':
+                        self.set_pagestyle(document, 'ScaleToPagesY', 1)
+                    elif op.spreadsheetfitpage == 'all':
+                        self.set_pagestyle(document, 'ScaleToPages', 1)
 
             ### Import style template
             phase = "import-style"

--- a/unoconv
+++ b/unoconv
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import time
+import signal
 
 __version__ = '0.7'
 
@@ -1283,10 +1284,15 @@ def die(ret, msg=None):
 
     sys.exit(ret)
 
+def term_signal_handler(signal, frame):
+    raise KeyboardInterrupt
+
 def main():
     global convertor, exitcode
     convertor = None
 
+    signal.signal(signal.SIGINT, term_signal_handler)
+    signal.signal(signal.SIGTERM, term_signal_handler)
     try:
         if op.listener:
             listener = Listener()

--- a/unoconv
+++ b/unoconv
@@ -540,6 +540,7 @@ class Options:
         self.splitspreadsheet = False
         self.splitspreadsheetqueue = None
         self.spreadsheetidx = None
+        self.spreadsheetfitpage = False
 
         ### Get options from the commandline
         try:
@@ -549,7 +550,7 @@ class Options:
                  'outputpath', 'password=', 'pipe=', 'port=', 'preserve',
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
                  'verbose', 'version',
-                 'split-spreadsheet', 'spreadsheet-idx='] )
+                 'spreadsheet-split', 'spreadsheet-idx=', 'spreadsheet-fitpage'] )
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
@@ -653,8 +654,10 @@ class Options:
                     size =  list(map(lambda s: intFunc(s), optValue.split('x')))
                     if (2 == len(size)):
                         self.papersize = size
-            elif opt in ['--split-spreadsheet']:
+            elif opt in ['--spreadsheet-split']:
                 self.splitspreadsheet = True
+            elif opt in ['--spreadsheet-fitpage']:
+                self.spreadsheetfitpage = True
             elif opt in ['--spreadsheet-idx']:
                 self.spreadsheetidx = int(arg)
 
@@ -758,8 +761,9 @@ unoconv options:
                                           eg. -P PaperOrientation=landscape
                                         PapserSize: specify printer paper size, paper format should set to USER, size=widthxheight
                                           eg. -P PaperSize=130x200 means width=130, height=200
-      --split-spreadsheet             split worksheets in spreadsheet
+      --spreadsheet-split             split worksheets in spreadsheet
       --spreadsheet-idx=idx           specify spreadsheet idx
+      --spreadsheet-fitpage           worksheet fit page
 ''', file=sys.stderr)
 
 class Convertor:
@@ -941,51 +945,23 @@ class Convertor:
                 raise UnoException("The document '%s' could not be opened." % inputurl, None)
 
             ### SpreadSheet options
-            if hasattr(document, 'getSheets'):
+            if 'com.sun.star.sheet.SpreadsheetDocument' in document.getSupportedServiceNames():
                 sheets = document.getSheets()
-                #sys.exit(0)
+
                 if op.spreadsheetidx != None:
-                    sheet = sheets.getByIndex(op.spreadsheetidx)
-                    document2 = self.desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
-                    sheets2 = document2.getSheets()
-                    sheets2.importSheet(document, sheet.getName(), 0)
-                    document.dispose()
-                    document.close(True)
-                    document = document2
-                    '''
-                    print('names', sheets.getElementNames())
-                    print('target: %s' % sheet.getName())
-                    for name in sheets.getElementNames():
-                        if name == sheet.getName():
-                            continue
-                        print('remove: %s' % name)
-                        sheets.removeByName(name)
-                        print('remove: %s done' % name)
-                    '''
+                    document = self.split_spreadsheet(document, op.spreadsheetidx)
+                    self.set_pagestyle(document, 'FooterIsOn', False)
+
                 elif op.splitspreadsheet:
                     if None == op.splitspreadsheetqueue:
                         op.splitspreadsheetqueue = [i for i in range(0, sheets.getCount())]
-                        document.dispose()
-                        document.close(True)
-                        return
-                    else:
-                        sheet = sheets.getByIndex(op.splitspreadsheetqueue[0])
-                        sheet = sheets.getByIndex(op.splitspreadsheetqueue[0])
-                        document2 = self.desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
-                        sheets2 = document2.getSheets()
-                        sheets2.importSheet(document, sheet.getName(), 0)
-                        document.dispose()
-                        document.close(True)
-                        document = document2
-                        '''
-                        print('names', sheets.getElementNames())
-                        print('target: %d %s' % (op.splitspreadsheetqueue[0], sheet.getName()))
-                        for name in sheets.getElementNames():
-                            if name == sheet.getName():
-                                continue
-                            print('remove: %s' % name)
-                            sheets.removeByName(name)
-                        '''
+
+                    document = self.split_spreadsheet(document, op.splitspreadsheetqueue[0])
+                    self.set_pagestyle(document, 'FooterIsOn', False)
+
+                if op.spreadsheetfitpage:
+                    self.set_pagestyle(document, 'ScaleToPages', 1)
+
             ### Import style template
             phase = "import-style"
             if op.template:
@@ -1188,6 +1164,22 @@ class Convertor:
                 error("unoconv: UnoException during %s phase in %s" % (phase, repr(e.__class__)))
                 exitcode = 2
                 pass
+    def split_spreadsheet(self, document, idx):
+        sheets = document.getSheets()
+        sheet = sheets.getByIndex(idx)
+        document2 = self.desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
+        sheets2 = document2.getSheets()
+        sheets2.importSheet(document, sheet.getName(), 0)
+        document.dispose()
+        document.close(True)
+        return document2
+
+    def set_pagestyle(self, document, key, value):
+        style = document.getStyleFamilies()
+        pageStyles = style.getByName('PageStyles')
+        for name in pageStyles.getElementNames():
+            pageStyle = pageStyles.getByName(name)
+            pageStyle.setPropertyValue(key, value)
 
 class Listener:
     def __init__(self):
@@ -1325,12 +1317,13 @@ def main():
                 convertor.convert(inputfn)
                 clean_convertor()
                 while None != op.splitspreadsheetqueue:
-                    convertor = Convertor()
-                    convertor.convert(inputfn)
-                    clean_convertor()
                     op.splitspreadsheetqueue = op.splitspreadsheetqueue[1:]
                     if (len(op.splitspreadsheetqueue) == 0):
                         op.splitspreadsheetqueue = None
+                        break
+                    convertor = Convertor()
+                    convertor.convert(inputfn)
+                    clean_convertor()
 
     except NoConnectException as e:
         error("unoconv: could not find an existing connection to LibreOffice at %s:%s." % (op.server, op.port))

--- a/unoconv
+++ b/unoconv
@@ -536,6 +536,9 @@ class Options:
         self.paperorientation = "PORTRAIT"
         self.papersize = ""
 
+        self.splitspreadsheet = False
+        self.spreadsheetidx = None
+
         ### Get options from the commandline
         try:
             opts, args = getopt.getopt (args, 'c:Dd:e:F:f:hi:LlM:no:p:s:T:t:P:vV',
@@ -543,7 +546,8 @@ class Options:
                  'help', 'import=', 'listener', 'meta=', 'no-launch', 'output=',
                  'outputpath', 'password=', 'pipe=', 'port=', 'preserve',
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
-                 'verbose', 'version'] )
+                 'verbose', 'version',
+                 'split-spreadsheet', 'spreadsheet-idx='] )
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
@@ -647,6 +651,10 @@ class Options:
                     size =  list(map(lambda s: intFunc(s), optValue.split('x')))
                     if (2 == len(size)):
                         self.papersize = size
+            elif opt in ['--split-spreadsheet']:
+                self.splitspreadsheet = True
+            elif opt in ['--spreadsheet-idx']:
+                self.spreadsheetidx = int(arg)
 
         ### Enable verbosity
         if self.verbose >= 2:
@@ -748,6 +756,8 @@ unoconv options:
                                           eg. -P PaperOrientation=landscape
                                         PapserSize: specify printer paper size, paper format should set to USER, size=widthxheight
                                           eg. -P PaperSize=130x200 means width=130, height=200
+      --split-spreadsheet             split worksheets in spreadsheet
+      --spreadsheet-idx=idx           specify spreadsheet idx
 ''', file=sys.stderr)
 
 class Convertor:
@@ -771,6 +781,9 @@ class Convertor:
         unosvcmgr = unocontext.ServiceManager
         self.desktop = unosvcmgr.createInstanceWithContext("com.sun.star.frame.Desktop", unocontext)
         self.cwd = unohelper.systemPathToFileUrl( os.getcwd() )
+
+        ### Note current spreadsheet idx
+        self.spreadsheet = None
 
         ### List all filters
 #        self.filters = unosvcmgr.createInstanceWithContext( "com.sun.star.document.FilterFactory", unocontext)
@@ -928,6 +941,36 @@ class Convertor:
             if not document:
                 raise UnoException("The document '%s' could not be opened." % inputurl, None)
 
+            ### SpreadSheet options
+            if hasattr(document, 'getSheets'):
+                controller = document.getCurrentController()
+                sheets = document.getSheets()
+                if op.spreadsheetidx != None:
+                    sheet = sheets.getByIndex(op.spreadsheetidx)
+                    for name in sheets.getElementNames():
+                        if name == sheet.getName():
+                            continue
+                        sheets.removeByName(name)
+                elif op.splitspreadsheet:
+                    if self.spreadsheet == None:
+                        #print('found %d sheets' % sheets.getCount())
+                        for i in range(0, sheets.getCount()):
+                            self.spreadsheet = i
+                            self.convert(inputfn)
+                        phase = "dispose"
+                        document.dispose()
+                        document.close(True)
+                        if not op.stdout and op.preserve:
+                            self.preserve(inputfn, outputfn)
+                        return
+                    else:
+                        sheet = sheets.getByIndex(self.spreadsheet)
+                        for name in sheets.getElementNames():
+                            if name == sheet.getName():
+                                continue
+                            sheets.removeByName(name)
+
+
             ### Import style template
             phase = "import-style"
             if op.template:
@@ -1075,6 +1118,8 @@ class Convertor:
                     outputfn = realpath(inbase + os.extsep + outputfmt.extension)
 
                 outputurl = unohelper.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
+                if self.spreadsheet != None:
+                    outputurl = outputurl.replace('.', '_' + str(self.spreadsheet) + '.')
 
             info(1, "Output file: %s" % outputurl)
 

--- a/unoconv
+++ b/unoconv
@@ -1219,6 +1219,19 @@ def die(ret, msg=None):
             info(3, 'Waiting for %s with pid %s to disappear.' % (ooproc.pid, product.ooName))
             ooproc.wait()
 
+        ### force remove if existed
+        if ooproc.poll() == None:
+            info(1, '%s instance still running, please investigate...' % product.ooName)
+            ooproc.wait()
+            info(2, '%s instance unsuccessfully terminated, sending KILL signal.' % product.ooName)
+            try:
+                os.kill(ooproc.pid, 9)
+            except AttributeError:
+                os.kill(ooproc.pid, 9)
+            info(3, 'Waiting for %s with pid %s to disappear.' % (ooproc.pid, product.ooName))
+            ooproc.wait()
+
+
     # allow Python GC to garbage collect pyuno object *before* exit call
     # which avoids random segmentation faults --vpa
     convertor = None

--- a/unoconv
+++ b/unoconv
@@ -538,6 +538,7 @@ class Options:
         self.papersize = ""
 
         self.splitspreadsheet = False
+        self.splitspreadsheetqueue = None
         self.spreadsheetidx = None
 
         ### Get options from the commandline
@@ -783,9 +784,6 @@ class Convertor:
         self.desktop = unosvcmgr.createInstanceWithContext("com.sun.star.frame.Desktop", unocontext)
         self.cwd = unohelper.systemPathToFileUrl( os.getcwd() )
 
-        ### Note current spreadsheet idx
-        self.spreadsheet = None
-
         ### List all filters
 #        self.filters = unosvcmgr.createInstanceWithContext( "com.sun.star.document.FilterFactory", unocontext)
 #        for filter in self.filters.getElementNames():
@@ -944,34 +942,50 @@ class Convertor:
 
             ### SpreadSheet options
             if hasattr(document, 'getSheets'):
-                controller = document.getCurrentController()
                 sheets = document.getSheets()
+                #sys.exit(0)
                 if op.spreadsheetidx != None:
                     sheet = sheets.getByIndex(op.spreadsheetidx)
+                    document2 = self.desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
+                    sheets2 = document2.getSheets()
+                    sheets2.importSheet(document, sheet.getName(), 0)
+                    document.dispose()
+                    document.close(True)
+                    document = document2
+                    '''
+                    print('names', sheets.getElementNames())
+                    print('target: %s' % sheet.getName())
                     for name in sheets.getElementNames():
                         if name == sheet.getName():
                             continue
+                        print('remove: %s' % name)
                         sheets.removeByName(name)
+                        print('remove: %s done' % name)
+                    '''
                 elif op.splitspreadsheet:
-                    if self.spreadsheet == None:
-                        #print('found %d sheets' % sheets.getCount())
-                        for i in range(0, sheets.getCount()):
-                            self.spreadsheet = i
-                            self.convert(inputfn)
-                        phase = "dispose"
+                    if None == op.splitspreadsheetqueue:
+                        op.splitspreadsheetqueue = [i for i in range(0, sheets.getCount())]
                         document.dispose()
                         document.close(True)
-                        if not op.stdout and op.preserve:
-                            self.preserve(inputfn, outputfn)
                         return
                     else:
-                        sheet = sheets.getByIndex(self.spreadsheet)
+                        sheet = sheets.getByIndex(op.splitspreadsheetqueue[0])
+                        sheet = sheets.getByIndex(op.splitspreadsheetqueue[0])
+                        document2 = self.desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
+                        sheets2 = document2.getSheets()
+                        sheets2.importSheet(document, sheet.getName(), 0)
+                        document.dispose()
+                        document.close(True)
+                        document = document2
+                        '''
+                        print('names', sheets.getElementNames())
+                        print('target: %d %s' % (op.splitspreadsheetqueue[0], sheet.getName()))
                         for name in sheets.getElementNames():
                             if name == sheet.getName():
                                 continue
+                            print('remove: %s' % name)
                             sheets.removeByName(name)
-
-
+                        '''
             ### Import style template
             phase = "import-style"
             if op.template:
@@ -1119,14 +1133,15 @@ class Convertor:
                     outputfn = realpath(inbase + os.extsep + outputfmt.extension)
 
                 outputurl = unohelper.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
-                if self.spreadsheet != None:
-                    outputurl = outputurl.replace('.', '_' + str(self.spreadsheet) + '.')
+                if op.splitspreadsheet and op.splitspreadsheetqueue != None:
+                    outputurl = outputurl.replace('.', '_' + str(op.splitspreadsheetqueue[0]) + '.')
 
             info(1, "Output file: %s" % outputurl)
 
             try:
                 document.storeToURL(outputurl, tuple(outputprops) )
             except IOException as e:
+                print(e)
                 raise UnoException("Unable to store document to %s (ErrCode %d)\n\nProperties: %s" % (outputurl, e.ErrCode, outputprops), None)
 
             phase = "dispose"
@@ -1200,31 +1215,11 @@ class Listener:
         else:
             info(1, "Existing %s listener found, nothing to do." % product.ooName)
 
-def error(msg):
-    "Output error message"
-    print(msg, file=sys.stderr)
-
-def info(level, msg):
-    "Output info message"
-    if 'op' not in globals():
-        pass
-    elif op.verbose >= 3 and level >= 3:
-        print("DEBUG:", msg, file=sys.stderr)
-    elif not op.stdout and level <= op.verbose:
-        print(msg, file=sys.stdout)
-    elif level <= op.verbose:
-        print(msg, file=sys.stderr)
-
-def die(ret, msg=None):
-    "Print optional error and exit with errorcode"
-    global convertor, ooproc, office
-
-    if msg:
-        error('Error: %s' % msg)
-
+def clean_convertor():
+    "clean convertor"
+    global convertor, ooproc
     ### Did we start our own listener instance ?
     if not op.listener and ooproc and convertor:
-
         ### If there is a GUI now attached to the instance, disable listener
         if convertor.desktop.getCurrentFrame():
             info(2, 'Trying to stop %s GUI listener.' % product.ooName)
@@ -1281,6 +1276,29 @@ def die(ret, msg=None):
     # allow Python GC to garbage collect pyuno object *before* exit call
     # which avoids random segmentation faults --vpa
     convertor = None
+    ooproc = None
+
+def error(msg):
+    "Output error message"
+    print(msg, file=sys.stderr)
+
+def info(level, msg):
+    "Output info message"
+    if 'op' not in globals():
+        pass
+    elif op.verbose >= 3 and level >= 3:
+        print("DEBUG:", msg, file=sys.stderr)
+    elif not op.stdout and level <= op.verbose:
+        print(msg, file=sys.stdout)
+    elif level <= op.verbose:
+        print(msg, file=sys.stderr)
+
+def die(ret, msg=None):
+    "Print optional error and exit with errorcode"
+    if msg:
+        error('Error: %s' % msg)
+
+    clean_convertor()
 
     sys.exit(ret)
 
@@ -1302,9 +1320,17 @@ def main():
             convertor = Convertor()
             convertor.convert(inputfn)
         elif op.filenames:
-            convertor = Convertor()
             for inputfn in op.filenames:
+                convertor = Convertor()
                 convertor.convert(inputfn)
+                clean_convertor()
+                while None != op.splitspreadsheetqueue:
+                    convertor = Convertor()
+                    convertor.convert(inputfn)
+                    clean_convertor()
+                    op.splitspreadsheetqueue = op.splitspreadsheetqueue[1:]
+                    if (len(op.splitspreadsheetqueue) == 0):
+                        op.splitspreadsheetqueue = None
 
     except NoConnectException as e:
         error("unoconv: could not find an existing connection to LibreOffice at %s:%s." % (op.server, op.port))

--- a/unoconv
+++ b/unoconv
@@ -533,6 +533,8 @@ class Options:
         self.timeout = 6
         self.verbose = 0
 
+        self.autoreset = False
+
         self.paperformat = "A4"
         self.paperorientation = "PORTRAIT"
         self.papersize = ""
@@ -550,6 +552,7 @@ class Options:
                  'outputpath', 'password=', 'pipe=', 'port=', 'preserve',
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
                  'verbose', 'version',
+                 'autoreset',
                  'spreadsheet-split', 'spreadsheet-idx=', 'spreadsheet-fitpage'] )
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
@@ -654,6 +657,8 @@ class Options:
                     size =  list(map(lambda s: intFunc(s), optValue.split('x')))
                     if (2 == len(size)):
                         self.papersize = size
+            elif opt in ['--autoreset']:
+                self.autoreset = True
             elif opt in ['--spreadsheet-split']:
                 self.splitspreadsheet = True
             elif opt in ['--spreadsheet-fitpage']:
@@ -761,6 +766,7 @@ unoconv options:
                                           eg. -P PaperOrientation=landscape
                                         PapserSize: specify printer paper size, paper format should set to USER, size=widthxheight
                                           eg. -P PaperSize=130x200 means width=130, height=200
+      --autoreset                     reset libreoffice for each file
       --spreadsheet-split             split worksheets in spreadsheet
       --spreadsheet-idx=idx           specify spreadsheet idx
       --spreadsheet-fitpage           worksheet fit page
@@ -1312,18 +1318,29 @@ def main():
             convertor = Convertor()
             convertor.convert(inputfn)
         elif op.filenames:
-            for inputfn in op.filenames:
-                convertor = Convertor()
-                convertor.convert(inputfn)
-                clean_convertor()
-                while None != op.splitspreadsheetqueue:
-                    op.splitspreadsheetqueue = op.splitspreadsheetqueue[1:]
-                    if (len(op.splitspreadsheetqueue) == 0):
-                        op.splitspreadsheetqueue = None
-                        break
+            if op.autoreset:
+                for inputfn in op.filenames:
                     convertor = Convertor()
                     convertor.convert(inputfn)
                     clean_convertor()
+                    while None != op.splitspreadsheetqueue:
+                        op.splitspreadsheetqueue = op.splitspreadsheetqueue[1:]
+                        if (len(op.splitspreadsheetqueue) == 0):
+                            op.splitspreadsheetqueue = None
+                            break
+                        convertor = Convertor()
+                        convertor.convert(inputfn)
+                        clean_convertor()
+            else:
+                convertor = Convertor()
+                for inputfn in op.filenames:
+                    convertor.convert(inputfn)
+                    while None != op.splitspreadsheetqueue:
+                        op.splitspreadsheetqueue = op.splitspreadsheetqueue[1:]
+                        if (len(op.splitspreadsheetqueue) == 0):
+                            op.splitspreadsheetqueue = None
+                            break
+                        convertor.convert(inputfn)
 
     except NoConnectException as e:
         error("unoconv: could not find an existing connection to LibreOffice at %s:%s." % (op.server, op.port))


### PR DESCRIPTION
1. spreadsheet options
 - split spreadsheet
 - specify worksheet index, then only output the worksheet
 - worksheet fit page option

2.support inter-process kill signal
process can fork exec unoconv. Therefore, parent can use signal to control it, ex timeout

3.auto reset option
libreoffice has memory leak potentially.
if you use one soffice.bin instance and doing lots of file operations, the system may out of memory.
auto reset help to restart soffice.bin for each file conversion.