### PR TITLE
Fix some flake8 errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E262,E265,E501,F821

--- a/unoconv
+++ b/unoconv
@@ -33,6 +33,7 @@ ooproc = None
 uno = unohelper = None
 exitcode = 0
 
+
 class Office:
     def __init__(self, basepath, urepath, unopath, pyuno, binary, python, pythonhome):
         self.basepath = basepath
@@ -49,6 +50,7 @@ class Office:
     def __repr__(self):
         return self.basepath
 
+
 ### Implement a path normalizer in order to make unoconv work on MacOS X
 ### (on which 'program' is a symlink to 'MacOSX' which seems to break unoconv)
 def realpath(*args):
@@ -64,66 +66,67 @@ def realpath(*args):
 ###
 ### See: http://user.services.openoffice.org/en/forum/viewtopic.php?f=45&t=36370&p=166783
 
+
 def find_offices():
     ret = []
     extrapaths = []
 
     ### Try using UNO_PATH first (in many incarnations, we'll see what sticks)
     if 'UNO_PATH' in os.environ:
-        extrapaths += [ os.environ['UNO_PATH'],
-                        os.path.dirname(os.environ['UNO_PATH']),
-                        os.path.dirname(os.path.dirname(os.environ['UNO_PATH'])) ]
+        extrapaths += [os.environ['UNO_PATH'],
+                       os.path.dirname(os.environ['UNO_PATH']),
+                       os.path.dirname(os.path.dirname(os.environ['UNO_PATH']))]
 
     else:
 
-        if os.name in ( 'nt', 'os2' ):
+        if os.name in ('nt', 'os2'):
             if 'PROGRAMFILES' in list(os.environ.keys()):
-                extrapaths += glob.glob(os.environ['PROGRAMFILES']+'\\LibreOffice*') + \
-                              glob.glob(os.environ['PROGRAMFILES']+'\\OpenOffice.org*')
+                extrapaths += (glob.glob(os.environ['PROGRAMFILES'] + '\\LibreOffice*') +
+                               glob.glob(os.environ['PROGRAMFILES'] + '\\OpenOffice.org*'))
 
             if 'PROGRAMFILES(X86)' in list(os.environ.keys()):
-                extrapaths += glob.glob(os.environ['PROGRAMFILES(X86)']+'\\LibreOffice*') + \
-                              glob.glob(os.environ['PROGRAMFILES(X86)']+'\\OpenOffice.org*')
+                extrapaths += (glob.glob(os.environ['PROGRAMFILES(X86)'] + '\\LibreOffice*') +
+                               glob.glob(os.environ['PROGRAMFILES(X86)'] + '\\OpenOffice.org*'))
 
-        elif os.name in ( 'mac', ) or sys.platform in ( 'darwin', ):
-            extrapaths += [ '/Applications/LibreOffice.app/Contents',
-                            '/Applications/NeoOffice.app/Contents',
-                            '/Applications/OpenOffice.app/Contents',
-                            '/Applications/OpenOffice.org.app/Contents' ]
+        elif os.name in ('mac',) or sys.platform in ('darwin',):
+            extrapaths += ['/Applications/LibreOffice.app/Contents',
+                           '/Applications/NeoOffice.app/Contents',
+                           '/Applications/OpenOffice.app/Contents',
+                           '/Applications/OpenOffice.org.app/Contents']
 
         else:
-            extrapaths += glob.glob('/usr/lib*/libreoffice*') + \
-                          glob.glob('/usr/lib*/openoffice*') + \
-                          glob.glob('/usr/lib*/ooo*') + \
-                          glob.glob('/opt/libreoffice*') + \
-                          glob.glob('/opt/openoffice*') + \
-                          glob.glob('/opt/ooo*') + \
-                          glob.glob('/usr/local/libreoffice*') + \
-                          glob.glob('/usr/local/openoffice*') + \
-                          glob.glob('/usr/local/ooo*') + \
-                          glob.glob('/usr/local/lib/libreoffice*')
+            extrapaths += (glob.glob('/usr/lib*/libreoffice*') +
+                           glob.glob('/usr/lib*/openoffice*') +
+                           glob.glob('/usr/lib*/ooo*') +
+                           glob.glob('/opt/libreoffice*') +
+                           glob.glob('/opt/openoffice*') +
+                           glob.glob('/opt/ooo*') +
+                           glob.glob('/usr/local/libreoffice*') +
+                           glob.glob('/usr/local/openoffice*') +
+                           glob.glob('/usr/local/ooo*') +
+                           glob.glob('/usr/local/lib/libreoffice*'))
 
     ### Find a working set for python UNO bindings
     for basepath in extrapaths:
-        if os.name in ( 'nt', 'os2' ):
-            officelibraries = ( 'pyuno.pyd', )
-            officebinaries = ( 'soffice.exe' ,)
-            pythonbinaries = ( 'python.exe', )
+        if os.name in ('nt', 'os2'):
+            officelibraries = ('pyuno.pyd',)
+            officebinaries = ('soffice.exe',)
+            pythonbinaries = ('python.exe',)
             pythonhomes = ()
-        elif os.name in ( 'mac', ) or sys.platform in ( 'darwin', ):
-            officelibraries = ( 'pyuno.so', 'libpyuno.dylib' )
-            officebinaries = ( 'soffice.bin', 'soffice')
-            pythonbinaries = ( 'python.bin', 'python' )
-            pythonhomes = ( 'OOoPython.framework/Versions/*/lib/python*', )
+        elif os.name in ('mac',) or sys.platform in ('darwin',):
+            officelibraries = ('pyuno.so', 'libpyuno.dylib')
+            officebinaries = ('soffice.bin', 'soffice')
+            pythonbinaries = ('python.bin', 'python')
+            pythonhomes = ('OOoPython.framework/Versions/*/lib/python*',)
         else:
-            officelibraries = ( 'pyuno.so', )
-            officebinaries = ( 'soffice.bin', )
-            pythonbinaries = ( 'python.bin', 'python', )
-            pythonhomes = ( 'python-core-*', )
+            officelibraries = ('pyuno.so',)
+            officebinaries = ('soffice.bin',)
+            pythonbinaries = ('python.bin', 'python',)
+            pythonhomes = ('python-core-*',)
 
         ### Older LibreOffice/OpenOffice and Windows use basis-link/ or basis/
         libpath = 'error'
-        for basis in ( 'basis-link', 'basis', '' ):
+        for basis in ('basis-link', 'basis', ''):
             for lib in officelibraries:
                 if os.path.isfile(realpath(basepath, basis, 'program', lib)):
                     libpath = realpath(basepath, basis, 'program')
@@ -141,7 +144,7 @@ def find_offices():
 
         ### MacOSX have soffice binaries installed in MacOS subdirectory, not program
         unopath = 'error'
-        for basis in ( 'basis-link', 'basis', '' ):
+        for basis in ('basis-link', 'basis', ''):
             for bin in officebinaries:
                 if os.path.isfile(realpath(basepath, basis, 'program', bin)):
                     unopath = realpath(basepath, basis, 'program')
@@ -159,8 +162,8 @@ def find_offices():
 
         ### Windows does not provide or need a URE/lib directory ?
         urepath = ''
-        for basis in ( 'basis-link', 'basis', '' ):
-            for ure in ( 'ure-link', 'ure', 'URE', '' ):
+        for basis in ('basis-link', 'basis', ''):
+            for ure in ('ure-link', 'ure', 'URE', ''):
                 if os.path.isfile(realpath(basepath, basis, ure, 'lib', 'unorc')):
                     urepath = realpath(basepath, basis, ure)
                     info(3, "Found %s in %s" % ('unorc', realpath(urepath, 'lib')))
@@ -197,6 +200,7 @@ def find_offices():
                               sys.executable, None))
     return ret
 
+
 def office_environ(office):
     ### Set PATH so that crash_report is found
     if 'PATH' in os.environ:
@@ -209,31 +213,32 @@ def office_environ(office):
 
     ### Set URE_BOOTSTRAP so that "uno.getComponentContext()" bootstraps a complete
     ### UNO environment
-    if os.name in ( 'nt', 'os2' ):
+    if os.name in ('nt', 'os2'):
         os.environ['URE_BOOTSTRAP'] = 'vnd.sun.star.pathname:' + realpath(office.basepath, 'program', 'fundamental.ini')
     else:
         os.environ['URE_BOOTSTRAP'] = 'vnd.sun.star.pathname:' + realpath(office.basepath, 'program', 'fundamentalrc')
 
         ### Set LD_LIBRARY_PATH so that "import pyuno" finds libpyuno.so:
         if 'LD_LIBRARY_PATH' in os.environ:
-            os.environ['LD_LIBRARY_PATH'] = office.unopath + os.pathsep + \
-                                            realpath(office.urepath, 'lib') + os.pathsep + \
-                                            os.environ['LD_LIBRARY_PATH']
+            os.environ['LD_LIBRARY_PATH'] = (office.unopath + os.pathsep +
+                                             realpath(office.urepath, 'lib') + os.pathsep +
+                                             os.environ['LD_LIBRARY_PATH'])
         else:
-            os.environ['LD_LIBRARY_PATH'] = office.unopath + os.pathsep + \
-                                            realpath(office.urepath, 'lib')
+            os.environ['LD_LIBRARY_PATH'] = (office.unopath + os.pathsep +
+                                             realpath(office.urepath, 'lib'))
 
     if office.pythonhome:
-        for libpath in ( realpath(office.pythonhome, 'lib'),
-                         realpath(office.pythonhome, 'lib', 'lib-dynload'),
-                         realpath(office.pythonhome, 'lib', 'lib-tk'),
-                         realpath(office.pythonhome, 'lib', 'site-packages'),
-                         office.unopath):
+        for libpath in (realpath(office.pythonhome, 'lib'),
+                        realpath(office.pythonhome, 'lib', 'lib-dynload'),
+                        realpath(office.pythonhome, 'lib', 'lib-tk'),
+                        realpath(office.pythonhome, 'lib', 'site-packages'),
+                        office.unopath):
             sys.path.insert(0, libpath)
     else:
         ### Still needed for system python using LibreOffice UNO bindings
         ### Although we prefer to use a system UNO binding in this case
         sys.path.append(office.unopath)
+
 
 def debug_office():
     if 'URE_BOOTSTRAP' in os.environ:
@@ -250,14 +255,15 @@ def debug_office():
     if 'LD_LIBRARY_PATH' in os.environ:
         print('LD_LIBRARY_PATH=%s' % os.environ['LD_LIBRARY_PATH'], file=sys.stderr)
 
+
 def python_switch(office):
     if office.pythonhome:
         os.environ['PYTHONHOME'] = office.pythonhome
-        os.environ['PYTHONPATH'] = realpath(office.pythonhome, 'lib') + os.pathsep + \
-                                   realpath(office.pythonhome, 'lib', 'lib-dynload') + os.pathsep + \
-                                   realpath(office.pythonhome, 'lib', 'lib-tk') + os.pathsep + \
-                                   realpath(office.pythonhome, 'lib', 'site-packages') + os.pathsep + \
-                                   office.unopath
+        os.environ['PYTHONPATH'] = (realpath(office.pythonhome, 'lib') + os.pathsep +
+                                    realpath(office.pythonhome, 'lib', 'lib-dynload') + os.pathsep +
+                                    realpath(office.pythonhome, 'lib', 'lib-tk') + os.pathsep +
+                                    realpath(office.pythonhome, 'lib', 'site-packages') + os.pathsep +
+                                    office.unopath)
 
     os.environ['UNO_PATH'] = office.unopath
 
@@ -272,12 +278,12 @@ def python_switch(office):
 
         ### Set LD_LIBRARY_PATH so that "import pyuno" finds libpyuno.so:
         if 'LD_LIBRARY_PATH' in os.environ:
-            os.environ['LD_LIBRARY_PATH'] = office.unopath + os.pathsep + \
-                                            realpath(office.urepath, 'lib') + os.pathsep + \
-                                            os.environ['LD_LIBRARY_PATH']
+            os.environ['LD_LIBRARY_PATH'] = (office.unopath + os.pathsep +
+                                             realpath(office.urepath, 'lib') + os.pathsep +
+                                             os.environ['LD_LIBRARY_PATH'])
         else:
-            os.environ['LD_LIBRARY_PATH'] = office.unopath + os.pathsep + \
-                                            realpath(office.urepath, 'lib')
+            os.environ['LD_LIBRARY_PATH'] = (office.unopath + os.pathsep +
+                                             realpath(office.urepath, 'lib'))
 
         try:
             os.execvpe(office.python, [office.python, ] + sys.argv[0:], os.environ)
@@ -296,6 +302,7 @@ def python_switch(office):
             ret = os.spawnvpe(os.P_WAIT, office.python, [office.python, ] + sys.argv[0:], os.environ)
             sys.exit(ret)
 
+
 class Fmt:
     def __init__(self, doctype, name, extension, summary, filter):
         self.doctype = doctype
@@ -309,6 +316,7 @@ class Fmt:
 
     def __repr__(self):
         return "%s/%s" % (self.name, self.doctype)
+
 
 class FmtList:
     def __init__(self):
@@ -348,161 +356,162 @@ class FmtList:
 fmts = FmtList()
 
 ### TextDocument
-fmts.add('document', 'bib', 'bib', 'BibTeX', 'BibTeX_Writer') ### 22
-fmts.add('document', 'doc', 'doc', 'Microsoft Word 97/2000/XP', 'MS Word 97') ### 29
-fmts.add('document', 'doc6', 'doc', 'Microsoft Word 6.0', 'MS WinWord 6.0') ### 24
-fmts.add('document', 'doc95', 'doc', 'Microsoft Word 95', 'MS Word 95') ### 28
-fmts.add('document', 'docbook', 'xml', 'DocBook', 'DocBook File') ### 39
+fmts.add('document', 'bib', 'bib', 'BibTeX', 'BibTeX_Writer')  ### 22
+fmts.add('document', 'doc', 'doc', 'Microsoft Word 97/2000/XP', 'MS Word 97')  ### 29
+fmts.add('document', 'doc6', 'doc', 'Microsoft Word 6.0', 'MS WinWord 6.0')  ### 24
+fmts.add('document', 'doc95', 'doc', 'Microsoft Word 95', 'MS Word 95')  ### 28
+fmts.add('document', 'docbook', 'xml', 'DocBook', 'DocBook File')  ### 39
 fmts.add('document', 'docx', 'docx', 'Microsoft Office Open XML', 'Office Open XML Text')
 fmts.add('document', 'docx7', 'docx', 'Microsoft Office Open XML', 'MS Word 2007 XML')
 fmts.add('document', 'fodt', 'fodt', 'OpenDocument Text (Flat XML)', 'OpenDocument Text Flat XML')
-fmts.add('document', 'html', 'html', 'HTML Document (OpenOffice.org Writer)', 'HTML (StarWriter)') ### 3
-fmts.add('document', 'latex', 'ltx', 'LaTeX 2e', 'LaTeX_Writer') ### 31
+fmts.add('document', 'html', 'html', 'HTML Document (OpenOffice.org Writer)', 'HTML (StarWriter)')  ### 3
+fmts.add('document', 'latex', 'ltx', 'LaTeX 2e', 'LaTeX_Writer')  ### 31
 fmts.add('document', 'mediawiki', 'txt', 'MediaWiki', 'MediaWiki')
-fmts.add('document', 'odt', 'odt', 'ODF Text Document', 'writer8') ### 10
-fmts.add('document', 'ooxml', 'xml', 'Microsoft Office Open XML', 'MS Word 2003 XML') ### 11
-fmts.add('document', 'ott', 'ott', 'Open Document Text', 'writer8_template') ### 21
+fmts.add('document', 'odt', 'odt', 'ODF Text Document', 'writer8')  ### 10
+fmts.add('document', 'ooxml', 'xml', 'Microsoft Office Open XML', 'MS Word 2003 XML')  ### 11
+fmts.add('document', 'ott', 'ott', 'Open Document Text', 'writer8_template')  ### 21
 fmts.add('document', 'pdb', 'pdb', 'AportisDoc (Palm)', 'AportisDoc Palm DB')
-fmts.add('document', 'pdf', 'pdf', 'Portable Document Format', 'writer_pdf_Export') ### 18
+fmts.add('document', 'pdf', 'pdf', 'Portable Document Format', 'writer_pdf_Export')  ### 18
 fmts.add('document', 'psw', 'psw', 'Pocket Word', 'PocketWord File')
-fmts.add('document', 'rtf', 'rtf', 'Rich Text Format', 'Rich Text Format') ### 16
-fmts.add('document', 'sdw', 'sdw', 'StarWriter 5.0', 'StarWriter 5.0') ### 23
-fmts.add('document', 'sdw4', 'sdw', 'StarWriter 4.0', 'StarWriter 4.0') ### 2
-fmts.add('document', 'sdw3', 'sdw', 'StarWriter 3.0', 'StarWriter 3.0') ### 20
-fmts.add('document', 'stw', 'stw', 'Open Office.org 1.0 Text Document Template', 'writer_StarOffice_XML_Writer_Template') ### 9
-fmts.add('document', 'sxw', 'sxw', 'Open Office.org 1.0 Text Document', 'StarOffice XML (Writer)') ### 1
-fmts.add('document', 'text', 'txt', 'Text Encoded', 'Text (encoded)') ### 26
-fmts.add('document', 'txt', 'txt', 'Text', 'Text') ### 34
-fmts.add('document', 'uot', 'uot', 'Unified Office Format text','UOF text') ### 27
-fmts.add('document', 'vor', 'vor', 'StarWriter 5.0 Template', 'StarWriter 5.0 Vorlage/Template') ### 6
-fmts.add('document', 'vor4', 'vor', 'StarWriter 4.0 Template', 'StarWriter 4.0 Vorlage/Template') ### 5
-fmts.add('document', 'vor3', 'vor', 'StarWriter 3.0 Template', 'StarWriter 3.0 Vorlage/Template') ### 4
+fmts.add('document', 'rtf', 'rtf', 'Rich Text Format', 'Rich Text Format')  ### 16
+fmts.add('document', 'sdw', 'sdw', 'StarWriter 5.0', 'StarWriter 5.0')  ### 23
+fmts.add('document', 'sdw4', 'sdw', 'StarWriter 4.0', 'StarWriter 4.0')  ### 2
+fmts.add('document', 'sdw3', 'sdw', 'StarWriter 3.0', 'StarWriter 3.0')  ### 20
+fmts.add('document', 'stw', 'stw', 'Open Office.org 1.0 Text Document Template', 'writer_StarOffice_XML_Writer_Template')  ### 9
+fmts.add('document', 'sxw', 'sxw', 'Open Office.org 1.0 Text Document', 'StarOffice XML (Writer)')  ### 1
+fmts.add('document', 'text', 'txt', 'Text Encoded', 'Text (encoded)')  ### 26
+fmts.add('document', 'txt', 'txt', 'Text', 'Text')  ### 34
+fmts.add('document', 'uot', 'uot', 'Unified Office Format text', 'UOF text')  ### 27
+fmts.add('document', 'vor', 'vor', 'StarWriter 5.0 Template', 'StarWriter 5.0 Vorlage/Template')  ### 6
+fmts.add('document', 'vor4', 'vor', 'StarWriter 4.0 Template', 'StarWriter 4.0 Vorlage/Template')  ### 5
+fmts.add('document', 'vor3', 'vor', 'StarWriter 3.0 Template', 'StarWriter 3.0 Vorlage/Template')  ### 4
 fmts.add('document', 'wps', 'wps', 'Microsoft Works', 'MS_Works')
-fmts.add('document', 'xhtml', 'html', 'XHTML Document', 'XHTML Writer File') ### 33
+fmts.add('document', 'xhtml', 'html', 'XHTML Document', 'XHTML Writer File')  ### 33
 
 ### WebDocument
-fmts.add('web', 'etext', 'txt', 'Text Encoded (OpenOffice.org Writer/Web)', 'Text (encoded) (StarWriter/Web)') ### 14
-fmts.add('web', 'html10', 'html', 'OpenOffice.org 1.0 HTML Template', 'writer_web_StarOffice_XML_Writer_Web_Template') ### 11
-fmts.add('web', 'html', 'html', 'HTML Document', 'HTML') ### 2
-fmts.add('web', 'html', 'html', 'HTML Document Template', 'writerweb8_writer_template') ### 13
-fmts.add('web', 'mediawiki', 'txt', 'MediaWiki', 'MediaWiki_Web') ### 9
-fmts.add('web', 'pdf', 'pdf', 'PDF - Portable Document Format', 'writer_web_pdf_Export') ### 10
-fmts.add('web', 'sdw3', 'sdw', 'StarWriter 3.0 (OpenOffice.org Writer/Web)', 'StarWriter 3.0 (StarWriter/Web)') ### 3
-fmts.add('web', 'sdw4', 'sdw', 'StarWriter 4.0 (OpenOffice.org Writer/Web)', 'StarWriter 4.0 (StarWriter/Web)') ### 4
-fmts.add('web', 'sdw', 'sdw', 'StarWriter 5.0 (OpenOffice.org Writer/Web)', 'StarWriter 5.0 (StarWriter/Web)') ### 5
-fmts.add('web', 'txt', 'txt', 'OpenOffice.org Text (OpenOffice.org Writer/Web)', 'writerweb8_writer') ### 12
-fmts.add('web', 'text10', 'txt', 'OpenOffice.org 1.0 Text Document (OpenOffice.org Writer/Web)', 'writer_web_StarOffice_XML_Writer') ### 15
-fmts.add('web', 'text', 'txt', 'Text (OpenOffice.org Writer/Web)', 'Text (StarWriter/Web)') ### 8
-fmts.add('web', 'vor4', 'vor', 'StarWriter/Web 4.0 Template', 'StarWriter/Web 4.0 Vorlage/Template') ### 6
-fmts.add('web', 'vor', 'vor', 'StarWriter/Web 5.0 Template', 'StarWriter/Web 5.0 Vorlage/Template') ### 7
+fmts.add('web', 'etext', 'txt', 'Text Encoded (OpenOffice.org Writer/Web)', 'Text (encoded) (StarWriter/Web)')  ### 14
+fmts.add('web', 'html10', 'html', 'OpenOffice.org 1.0 HTML Template', 'writer_web_StarOffice_XML_Writer_Web_Template')  ### 11
+fmts.add('web', 'html', 'html', 'HTML Document', 'HTML')  ### 2
+fmts.add('web', 'html', 'html', 'HTML Document Template', 'writerweb8_writer_template')  ### 13
+fmts.add('web', 'mediawiki', 'txt', 'MediaWiki', 'MediaWiki_Web')  ### 9
+fmts.add('web', 'pdf', 'pdf', 'PDF - Portable Document Format', 'writer_web_pdf_Export')  ### 10
+fmts.add('web', 'sdw3', 'sdw', 'StarWriter 3.0 (OpenOffice.org Writer/Web)', 'StarWriter 3.0 (StarWriter/Web)')  ### 3
+fmts.add('web', 'sdw4', 'sdw', 'StarWriter 4.0 (OpenOffice.org Writer/Web)', 'StarWriter 4.0 (StarWriter/Web)')  ### 4
+fmts.add('web', 'sdw', 'sdw', 'StarWriter 5.0 (OpenOffice.org Writer/Web)', 'StarWriter 5.0 (StarWriter/Web)')  ### 5
+fmts.add('web', 'txt', 'txt', 'OpenOffice.org Text (OpenOffice.org Writer/Web)', 'writerweb8_writer')  ### 12
+fmts.add('web', 'text10', 'txt', 'OpenOffice.org 1.0 Text Document (OpenOffice.org Writer/Web)', 'writer_web_StarOffice_XML_Writer')  ### 15
+fmts.add('web', 'text', 'txt', 'Text (OpenOffice.org Writer/Web)', 'Text (StarWriter/Web)')  ### 8
+fmts.add('web', 'vor4', 'vor', 'StarWriter/Web 4.0 Template', 'StarWriter/Web 4.0 Vorlage/Template')  ### 6
+fmts.add('web', 'vor', 'vor', 'StarWriter/Web 5.0 Template', 'StarWriter/Web 5.0 Vorlage/Template')  ### 7
 
 ### Spreadsheet
-fmts.add('spreadsheet', 'csv', 'csv', 'Text CSV', 'Text - txt - csv (StarCalc)') ### 16
-fmts.add('spreadsheet', 'dbf', 'dbf', 'dBASE', 'dBase') ### 22
-fmts.add('spreadsheet', 'dif', 'dif', 'Data Interchange Format', 'DIF') ### 5
+fmts.add('spreadsheet', 'csv', 'csv', 'Text CSV', 'Text - txt - csv (StarCalc)')  ### 16
+fmts.add('spreadsheet', 'dbf', 'dbf', 'dBASE', 'dBase')  ### 22
+fmts.add('spreadsheet', 'dif', 'dif', 'Data Interchange Format', 'DIF')  ### 5
 fmts.add('spreadsheet', 'fods', 'fods', 'OpenDocument Spreadsheet (Flat XML)', 'OpenDocument Spreadsheet Flat XML')
-fmts.add('spreadsheet', 'html', 'html', 'HTML Document (OpenOffice.org Calc)', 'HTML (StarCalc)') ### 7
-fmts.add('spreadsheet', 'ods', 'ods', 'ODF Spreadsheet', 'calc8') ### 15
-fmts.add('spreadsheet', 'ooxml', 'xml', 'Microsoft Excel 2003 XML', 'MS Excel 2003 XML') ### 23
-fmts.add('spreadsheet', 'ots', 'ots', 'ODF Spreadsheet Template', 'calc8_template') ### 14
-fmts.add('spreadsheet', 'pdf', 'pdf', 'Portable Document Format', 'calc_pdf_Export') ### 34
+fmts.add('spreadsheet', 'html', 'html', 'HTML Document (OpenOffice.org Calc)', 'HTML (StarCalc)')  ### 7
+fmts.add('spreadsheet', 'ods', 'ods', 'ODF Spreadsheet', 'calc8')  ### 15
+fmts.add('spreadsheet', 'ooxml', 'xml', 'Microsoft Excel 2003 XML', 'MS Excel 2003 XML')  ### 23
+fmts.add('spreadsheet', 'ots', 'ots', 'ODF Spreadsheet Template', 'calc8_template')  ### 14
+fmts.add('spreadsheet', 'pdf', 'pdf', 'Portable Document Format', 'calc_pdf_Export')  ### 34
 fmts.add('spreadsheet', 'pxl', 'pxl', 'Pocket Excel', 'Pocket Excel')
-fmts.add('spreadsheet', 'sdc', 'sdc', 'StarCalc 5.0', 'StarCalc 5.0') ### 31
-fmts.add('spreadsheet', 'sdc4', 'sdc', 'StarCalc 4.0', 'StarCalc 4.0') ### 11
-fmts.add('spreadsheet', 'sdc3', 'sdc', 'StarCalc 3.0', 'StarCalc 3.0') ### 29
-fmts.add('spreadsheet', 'slk', 'slk', 'SYLK', 'SYLK') ### 35
-fmts.add('spreadsheet', 'stc', 'stc', 'OpenOffice.org 1.0 Spreadsheet Template', 'calc_StarOffice_XML_Calc_Template') ### 2
-fmts.add('spreadsheet', 'sxc', 'sxc', 'OpenOffice.org 1.0 Spreadsheet', 'StarOffice XML (Calc)') ### 3
-fmts.add('spreadsheet', 'uos', 'uos', 'Unified Office Format spreadsheet', 'UOF spreadsheet') ### 9
-fmts.add('spreadsheet', 'vor3', 'vor', 'StarCalc 3.0 Template', 'StarCalc 3.0 Vorlage/Template') ### 18
-fmts.add('spreadsheet', 'vor4', 'vor', 'StarCalc 4.0 Template', 'StarCalc 4.0 Vorlage/Template') ### 19
-fmts.add('spreadsheet', 'vor', 'vor', 'StarCalc 5.0 Template', 'StarCalc 5.0 Vorlage/Template') ### 20
-fmts.add('spreadsheet', 'xhtml', 'xhtml', 'XHTML', 'XHTML Calc File') ### 26
-fmts.add('spreadsheet', 'xls', 'xls', 'Microsoft Excel 97/2000/XP', 'MS Excel 97') ### 12
-fmts.add('spreadsheet', 'xls5', 'xls', 'Microsoft Excel 5.0', 'MS Excel 5.0/95') ### 8
-fmts.add('spreadsheet', 'xls95', 'xls', 'Microsoft Excel 95', 'MS Excel 95') ### 10
-fmts.add('spreadsheet', 'xlt', 'xlt', 'Microsoft Excel 97/2000/XP Template', 'MS Excel 97 Vorlage/Template') ### 6
-fmts.add('spreadsheet', 'xlt5', 'xlt', 'Microsoft Excel 5.0 Template', 'MS Excel 5.0/95 Vorlage/Template') ### 28
-fmts.add('spreadsheet', 'xlt95', 'xlt', 'Microsoft Excel 95 Template', 'MS Excel 95 Vorlage/Template') ### 21
+fmts.add('spreadsheet', 'sdc', 'sdc', 'StarCalc 5.0', 'StarCalc 5.0')  ### 31
+fmts.add('spreadsheet', 'sdc4', 'sdc', 'StarCalc 4.0', 'StarCalc 4.0')  ### 11
+fmts.add('spreadsheet', 'sdc3', 'sdc', 'StarCalc 3.0', 'StarCalc 3.0')  ### 29
+fmts.add('spreadsheet', 'slk', 'slk', 'SYLK', 'SYLK')  ### 35
+fmts.add('spreadsheet', 'stc', 'stc', 'OpenOffice.org 1.0 Spreadsheet Template', 'calc_StarOffice_XML_Calc_Template')  ### 2
+fmts.add('spreadsheet', 'sxc', 'sxc', 'OpenOffice.org 1.0 Spreadsheet', 'StarOffice XML (Calc)')  ### 3
+fmts.add('spreadsheet', 'uos', 'uos', 'Unified Office Format spreadsheet', 'UOF spreadsheet')  ### 9
+fmts.add('spreadsheet', 'vor3', 'vor', 'StarCalc 3.0 Template', 'StarCalc 3.0 Vorlage/Template')  ### 18
+fmts.add('spreadsheet', 'vor4', 'vor', 'StarCalc 4.0 Template', 'StarCalc 4.0 Vorlage/Template')  ### 19
+fmts.add('spreadsheet', 'vor', 'vor', 'StarCalc 5.0 Template', 'StarCalc 5.0 Vorlage/Template')  ### 20
+fmts.add('spreadsheet', 'xhtml', 'xhtml', 'XHTML', 'XHTML Calc File')  ### 26
+fmts.add('spreadsheet', 'xls', 'xls', 'Microsoft Excel 97/2000/XP', 'MS Excel 97')  ### 12
+fmts.add('spreadsheet', 'xls5', 'xls', 'Microsoft Excel 5.0', 'MS Excel 5.0/95')  ### 8
+fmts.add('spreadsheet', 'xls95', 'xls', 'Microsoft Excel 95', 'MS Excel 95')  ### 10
+fmts.add('spreadsheet', 'xlt', 'xlt', 'Microsoft Excel 97/2000/XP Template', 'MS Excel 97 Vorlage/Template')  ### 6
+fmts.add('spreadsheet', 'xlt5', 'xlt', 'Microsoft Excel 5.0 Template', 'MS Excel 5.0/95 Vorlage/Template')  ### 28
+fmts.add('spreadsheet', 'xlt95', 'xlt', 'Microsoft Excel 95 Template', 'MS Excel 95 Vorlage/Template')  ### 21
 fmts.add('spreadsheet', 'xlsx', 'xlsx', 'Microsoft Excel 2007/2010 XML', 'Calc MS Excel 2007 XML')
 
 ### Graphics
-fmts.add('graphics', 'bmp', 'bmp', 'Windows Bitmap', 'draw_bmp_Export') ### 21
-fmts.add('graphics', 'emf', 'emf', 'Enhanced Metafile', 'draw_emf_Export') ### 15
-fmts.add('graphics', 'eps', 'eps', 'Encapsulated PostScript', 'draw_eps_Export') ### 48
+fmts.add('graphics', 'bmp', 'bmp', 'Windows Bitmap', 'draw_bmp_Export')  ### 21
+fmts.add('graphics', 'emf', 'emf', 'Enhanced Metafile', 'draw_emf_Export')  ### 15
+fmts.add('graphics', 'eps', 'eps', 'Encapsulated PostScript', 'draw_eps_Export')  ### 48
 fmts.add('graphics', 'fodg', 'fodg', 'OpenDocument Drawing (Flat XML)', 'OpenDocument Drawing Flat XML')
-fmts.add('graphics', 'gif', 'gif', 'Graphics Interchange Format', 'draw_gif_Export') ### 30
-fmts.add('graphics', 'html', 'html', 'HTML Document (OpenOffice.org Draw)', 'draw_html_Export') ### 37
-fmts.add('graphics', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'draw_jpg_Export') ### 3
-fmts.add('graphics', 'met', 'met', 'OS/2 Metafile', 'draw_met_Export') ### 43
-fmts.add('graphics', 'odd', 'odd', 'OpenDocument Drawing', 'draw8') ### 6
-fmts.add('graphics', 'otg', 'otg', 'OpenDocument Drawing Template', 'draw8_template') ### 20
-fmts.add('graphics', 'pbm', 'pbm', 'Portable Bitmap', 'draw_pbm_Export') ### 14
-fmts.add('graphics', 'pct', 'pct', 'Mac Pict', 'draw_pct_Export') ### 41
-fmts.add('graphics', 'pdf', 'pdf', 'Portable Document Format', 'draw_pdf_Export') ### 28
-fmts.add('graphics', 'pgm', 'pgm', 'Portable Graymap', 'draw_pgm_Export') ### 11
-fmts.add('graphics', 'png', 'png', 'Portable Network Graphic', 'draw_png_Export') ### 2
-fmts.add('graphics', 'ppm', 'ppm', 'Portable Pixelmap', 'draw_ppm_Export') ### 5
-fmts.add('graphics', 'ras', 'ras', 'Sun Raster Image', 'draw_ras_Export') ## 31
-fmts.add('graphics', 'std', 'std', 'OpenOffice.org 1.0 Drawing Template', 'draw_StarOffice_XML_Draw_Template') ### 53
-fmts.add('graphics', 'svg', 'svg', 'Scalable Vector Graphics', 'draw_svg_Export') ### 50
-fmts.add('graphics', 'svm', 'svm', 'StarView Metafile', 'draw_svm_Export') ### 55
-fmts.add('graphics', 'swf', 'swf', 'Macromedia Flash (SWF)', 'draw_flash_Export') ### 23
-fmts.add('graphics', 'sxd', 'sxd', 'OpenOffice.org 1.0 Drawing', 'StarOffice XML (Draw)') ### 26
-fmts.add('graphics', 'sxd3', 'sxd', 'StarDraw 3.0', 'StarDraw 3.0') ### 40
-fmts.add('graphics', 'sxd5', 'sxd', 'StarDraw 5.0', 'StarDraw 5.0') ### 44
+fmts.add('graphics', 'gif', 'gif', 'Graphics Interchange Format', 'draw_gif_Export')  ### 30
+fmts.add('graphics', 'html', 'html', 'HTML Document (OpenOffice.org Draw)', 'draw_html_Export')  ### 37
+fmts.add('graphics', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'draw_jpg_Export')  ### 3
+fmts.add('graphics', 'met', 'met', 'OS/2 Metafile', 'draw_met_Export')  ### 43
+fmts.add('graphics', 'odd', 'odd', 'OpenDocument Drawing', 'draw8')  ### 6
+fmts.add('graphics', 'otg', 'otg', 'OpenDocument Drawing Template', 'draw8_template')  ### 20
+fmts.add('graphics', 'pbm', 'pbm', 'Portable Bitmap', 'draw_pbm_Export')  ### 14
+fmts.add('graphics', 'pct', 'pct', 'Mac Pict', 'draw_pct_Export')  ### 41
+fmts.add('graphics', 'pdf', 'pdf', 'Portable Document Format', 'draw_pdf_Export')  ### 28
+fmts.add('graphics', 'pgm', 'pgm', 'Portable Graymap', 'draw_pgm_Export')  ### 11
+fmts.add('graphics', 'png', 'png', 'Portable Network Graphic', 'draw_png_Export')  ### 2
+fmts.add('graphics', 'ppm', 'ppm', 'Portable Pixelmap', 'draw_ppm_Export')  ### 5
+fmts.add('graphics', 'ras', 'ras', 'Sun Raster Image', 'draw_ras_Export')  ## 31
+fmts.add('graphics', 'std', 'std', 'OpenOffice.org 1.0 Drawing Template', 'draw_StarOffice_XML_Draw_Template')  ### 53
+fmts.add('graphics', 'svg', 'svg', 'Scalable Vector Graphics', 'draw_svg_Export')  ### 50
+fmts.add('graphics', 'svm', 'svm', 'StarView Metafile', 'draw_svm_Export')  ### 55
+fmts.add('graphics', 'swf', 'swf', 'Macromedia Flash (SWF)', 'draw_flash_Export')  ### 23
+fmts.add('graphics', 'sxd', 'sxd', 'OpenOffice.org 1.0 Drawing', 'StarOffice XML (Draw)')  ### 26
+fmts.add('graphics', 'sxd3', 'sxd', 'StarDraw 3.0', 'StarDraw 3.0')  ### 40
+fmts.add('graphics', 'sxd5', 'sxd', 'StarDraw 5.0', 'StarDraw 5.0')  ### 44
 fmts.add('graphics', 'sxw', 'sxw', 'StarOffice XML (Draw)', 'StarOffice XML (Draw)')
-fmts.add('graphics', 'tiff', 'tiff', 'Tagged Image File Format', 'draw_tif_Export') ### 13
-fmts.add('graphics', 'vor', 'vor', 'StarDraw 5.0 Template', 'StarDraw 5.0 Vorlage') ### 36
-fmts.add('graphics', 'vor3', 'vor', 'StarDraw 3.0 Template', 'StarDraw 3.0 Vorlage') ### 35
-fmts.add('graphics', 'wmf', 'wmf', 'Windows Metafile', 'draw_wmf_Export') ### 8
-fmts.add('graphics', 'xhtml', 'xhtml', 'XHTML', 'XHTML Draw File') ### 45
-fmts.add('graphics', 'xpm', 'xpm', 'X PixMap', 'draw_xpm_Export') ### 19
+fmts.add('graphics', 'tiff', 'tiff', 'Tagged Image File Format', 'draw_tif_Export')  ### 13
+fmts.add('graphics', 'vor', 'vor', 'StarDraw 5.0 Template', 'StarDraw 5.0 Vorlage')  ### 36
+fmts.add('graphics', 'vor3', 'vor', 'StarDraw 3.0 Template', 'StarDraw 3.0 Vorlage')  ### 35
+fmts.add('graphics', 'wmf', 'wmf', 'Windows Metafile', 'draw_wmf_Export')  ### 8
+fmts.add('graphics', 'xhtml', 'xhtml', 'XHTML', 'XHTML Draw File')  ### 45
+fmts.add('graphics', 'xpm', 'xpm', 'X PixMap', 'draw_xpm_Export')  ### 19
 
 ### Presentation
-fmts.add('presentation', 'bmp', 'bmp', 'Windows Bitmap', 'impress_bmp_Export') ### 15
-fmts.add('presentation', 'emf', 'emf', 'Enhanced Metafile', 'impress_emf_Export') ### 16
-fmts.add('presentation', 'eps', 'eps', 'Encapsulated PostScript', 'impress_eps_Export') ### 17
+fmts.add('presentation', 'bmp', 'bmp', 'Windows Bitmap', 'impress_bmp_Export')  ### 15
+fmts.add('presentation', 'emf', 'emf', 'Enhanced Metafile', 'impress_emf_Export')  ### 16
+fmts.add('presentation', 'eps', 'eps', 'Encapsulated PostScript', 'impress_eps_Export')  ### 17
 fmts.add('presentation', 'fodp', 'fodp', 'OpenDocument Presentation (Flat XML)', 'OpenDocument Presentation Flat XML')
-fmts.add('presentation', 'gif', 'gif', 'Graphics Interchange Format', 'impress_gif_Export') ### 18
-fmts.add('presentation', 'html', 'html', 'HTML Document (OpenOffice.org Impress)', 'impress_html_Export') ### 43
-fmts.add('presentation', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'impress_jpg_Export') ### 19
-fmts.add('presentation', 'met', 'met', 'OS/2 Metafile', 'impress_met_Export') ### 20
-fmts.add('presentation', 'odg', 'odg', 'ODF Drawing (Impress)', 'impress8_draw') ### 29
-fmts.add('presentation', 'odp', 'odp', 'ODF Presentation', 'impress8') ### 9
-fmts.add('presentation', 'otp', 'otp', 'ODF Presentation Template', 'impress8_template') ### 38
-fmts.add('presentation', 'pbm', 'pbm', 'Portable Bitmap', 'impress_pbm_Export') ### 21
-fmts.add('presentation', 'pct', 'pct', 'Mac Pict', 'impress_pct_Export') ### 22
-fmts.add('presentation', 'pdf', 'pdf', 'Portable Document Format', 'impress_pdf_Export') ### 23
-fmts.add('presentation', 'pgm', 'pgm', 'Portable Graymap', 'impress_pgm_Export') ### 24
-fmts.add('presentation', 'png', 'png', 'Portable Network Graphic', 'impress_png_Export') ### 25
+fmts.add('presentation', 'gif', 'gif', 'Graphics Interchange Format', 'impress_gif_Export')  ### 18
+fmts.add('presentation', 'html', 'html', 'HTML Document (OpenOffice.org Impress)', 'impress_html_Export')  ### 43
+fmts.add('presentation', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'impress_jpg_Export')  ### 19
+fmts.add('presentation', 'met', 'met', 'OS/2 Metafile', 'impress_met_Export')  ### 20
+fmts.add('presentation', 'odg', 'odg', 'ODF Drawing (Impress)', 'impress8_draw')  ### 29
+fmts.add('presentation', 'odp', 'odp', 'ODF Presentation', 'impress8')  ### 9
+fmts.add('presentation', 'otp', 'otp', 'ODF Presentation Template', 'impress8_template')  ### 38
+fmts.add('presentation', 'pbm', 'pbm', 'Portable Bitmap', 'impress_pbm_Export')  ### 21
+fmts.add('presentation', 'pct', 'pct', 'Mac Pict', 'impress_pct_Export')  ### 22
+fmts.add('presentation', 'pdf', 'pdf', 'Portable Document Format', 'impress_pdf_Export')  ### 23
+fmts.add('presentation', 'pgm', 'pgm', 'Portable Graymap', 'impress_pgm_Export')  ### 24
+fmts.add('presentation', 'png', 'png', 'Portable Network Graphic', 'impress_png_Export')  ### 25
 fmts.add('presentation', 'potm', 'potm', 'Microsoft PowerPoint 2007/2010 XML Template', 'Impress MS PowerPoint 2007 XML Template')
-fmts.add('presentation', 'pot', 'pot', 'Microsoft PowerPoint 97/2000/XP Template', 'MS PowerPoint 97 Vorlage') ### 3
-fmts.add('presentation', 'ppm', 'ppm', 'Portable Pixelmap', 'impress_ppm_Export') ### 26
-fmts.add('presentation', 'pptx', 'pptx', 'Microsoft PowerPoint 2007/2010 XML', 'Impress MS PowerPoint 2007 XML') ### 36
-fmts.add('presentation', 'pps', 'pps', 'Microsoft PowerPoint 97/2000/XP (Autoplay)', 'MS PowerPoint 97 Autoplay') ### 36
-fmts.add('presentation', 'ppt', 'ppt', 'Microsoft PowerPoint 97/2000/XP', 'MS PowerPoint 97') ### 36
-fmts.add('presentation', 'pwp', 'pwp', 'PlaceWare', 'placeware_Export') ### 30
-fmts.add('presentation', 'ras', 'ras', 'Sun Raster Image', 'impress_ras_Export') ### 27
-fmts.add('presentation', 'sda', 'sda', 'StarDraw 5.0 (OpenOffice.org Impress)', 'StarDraw 5.0 (StarImpress)') ### 8
-fmts.add('presentation', 'sdd', 'sdd', 'StarImpress 5.0', 'StarImpress 5.0') ### 6
-fmts.add('presentation', 'sdd3', 'sdd', 'StarDraw 3.0 (OpenOffice.org Impress)', 'StarDraw 3.0 (StarImpress)') ### 42
-fmts.add('presentation', 'sdd4', 'sdd', 'StarImpress 4.0', 'StarImpress 4.0') ### 37
-fmts.add('presentation', 'sxd', 'sxd', 'OpenOffice.org 1.0 Drawing (OpenOffice.org Impress)', 'impress_StarOffice_XML_Draw') ### 31
-fmts.add('presentation', 'sti', 'sti', 'OpenOffice.org 1.0 Presentation Template', 'impress_StarOffice_XML_Impress_Template') ### 5
-fmts.add('presentation', 'svg', 'svg', 'Scalable Vector Graphics', 'impress_svg_Export') ### 14
-fmts.add('presentation', 'svm', 'svm', 'StarView Metafile', 'impress_svm_Export') ### 13
-fmts.add('presentation', 'swf', 'swf', 'Macromedia Flash (SWF)', 'impress_flash_Export') ### 34
-fmts.add('presentation', 'sxi', 'sxi', 'OpenOffice.org 1.0 Presentation', 'StarOffice XML (Impress)') ### 41
-fmts.add('presentation', 'tiff', 'tiff', 'Tagged Image File Format', 'impress_tif_Export') ### 12
-fmts.add('presentation', 'uop', 'uop', 'Unified Office Format presentation', 'UOF presentation') ### 4
-fmts.add('presentation', 'vor', 'vor', 'StarImpress 5.0 Template', 'StarImpress 5.0 Vorlage') ### 40
-fmts.add('presentation', 'vor3', 'vor', 'StarDraw 3.0 Template (OpenOffice.org Impress)', 'StarDraw 3.0 Vorlage (StarImpress)') ###1
-fmts.add('presentation', 'vor4', 'vor', 'StarImpress 4.0 Template', 'StarImpress 4.0 Vorlage') ### 39
-fmts.add('presentation', 'vor5', 'vor', 'StarDraw 5.0 Template (OpenOffice.org Impress)', 'StarDraw 5.0 Vorlage (StarImpress)') ### 2
-fmts.add('presentation', 'wmf', 'wmf', 'Windows Metafile', 'impress_wmf_Export') ### 11
-fmts.add('presentation', 'xhtml', 'xml', 'XHTML', 'XHTML Impress File') ### 33
-fmts.add('presentation', 'xpm', 'xpm', 'X PixMap', 'impress_xpm_Export') ### 10
+fmts.add('presentation', 'pot', 'pot', 'Microsoft PowerPoint 97/2000/XP Template', 'MS PowerPoint 97 Vorlage')  ### 3
+fmts.add('presentation', 'ppm', 'ppm', 'Portable Pixelmap', 'impress_ppm_Export')  ### 26
+fmts.add('presentation', 'pptx', 'pptx', 'Microsoft PowerPoint 2007/2010 XML', 'Impress MS PowerPoint 2007 XML')  ### 36
+fmts.add('presentation', 'pps', 'pps', 'Microsoft PowerPoint 97/2000/XP (Autoplay)', 'MS PowerPoint 97 Autoplay')  ### 36
+fmts.add('presentation', 'ppt', 'ppt', 'Microsoft PowerPoint 97/2000/XP', 'MS PowerPoint 97')  ### 36
+fmts.add('presentation', 'pwp', 'pwp', 'PlaceWare', 'placeware_Export')  ### 30
+fmts.add('presentation', 'ras', 'ras', 'Sun Raster Image', 'impress_ras_Export')  ### 27
+fmts.add('presentation', 'sda', 'sda', 'StarDraw 5.0 (OpenOffice.org Impress)', 'StarDraw 5.0 (StarImpress)')  ### 8
+fmts.add('presentation', 'sdd', 'sdd', 'StarImpress 5.0', 'StarImpress 5.0')  ### 6
+fmts.add('presentation', 'sdd3', 'sdd', 'StarDraw 3.0 (OpenOffice.org Impress)', 'StarDraw 3.0 (StarImpress)')  ### 42
+fmts.add('presentation', 'sdd4', 'sdd', 'StarImpress 4.0', 'StarImpress 4.0')  ### 37
+fmts.add('presentation', 'sxd', 'sxd', 'OpenOffice.org 1.0 Drawing (OpenOffice.org Impress)', 'impress_StarOffice_XML_Draw')  ### 31
+fmts.add('presentation', 'sti', 'sti', 'OpenOffice.org 1.0 Presentation Template', 'impress_StarOffice_XML_Impress_Template')  ### 5
+fmts.add('presentation', 'svg', 'svg', 'Scalable Vector Graphics', 'impress_svg_Export')  ### 14
+fmts.add('presentation', 'svm', 'svm', 'StarView Metafile', 'impress_svm_Export')  ### 13
+fmts.add('presentation', 'swf', 'swf', 'Macromedia Flash (SWF)', 'impress_flash_Export')  ### 34
+fmts.add('presentation', 'sxi', 'sxi', 'OpenOffice.org 1.0 Presentation', 'StarOffice XML (Impress)')  ### 41
+fmts.add('presentation', 'tiff', 'tiff', 'Tagged Image File Format', 'impress_tif_Export')  ### 12
+fmts.add('presentation', 'uop', 'uop', 'Unified Office Format presentation', 'UOF presentation')  ### 4
+fmts.add('presentation', 'vor', 'vor', 'StarImpress 5.0 Template', 'StarImpress 5.0 Vorlage')  ### 40
+fmts.add('presentation', 'vor3', 'vor', 'StarDraw 3.0 Template (OpenOffice.org Impress)', 'StarDraw 3.0 Vorlage (StarImpress)')  ###1
+fmts.add('presentation', 'vor4', 'vor', 'StarImpress 4.0 Template', 'StarImpress 4.0 Vorlage')  ### 39
+fmts.add('presentation', 'vor5', 'vor', 'StarDraw 5.0 Template (OpenOffice.org Impress)', 'StarDraw 5.0 Vorlage (StarImpress)')  ### 2
+fmts.add('presentation', 'wmf', 'wmf', 'Windows Metafile', 'impress_wmf_Export')  ### 11
+fmts.add('presentation', 'xhtml', 'xml', 'XHTML', 'XHTML Impress File')  ### 33
+fmts.add('presentation', 'xpm', 'xpm', 'X PixMap', 'impress_xpm_Export')  ### 10
+
 
 class Options:
     def __init__(self, args):
@@ -539,12 +548,13 @@ class Options:
 
         ### Get options from the commandline
         try:
-            opts, args = getopt.getopt (args, 'c:Dd:e:F:f:hi:LlM:no:p:s:T:t:P:vV',
+            opts, args = getopt.getopt(
+                args, 'c:Dd:e:F:f:hi:LlM:no:p:s:T:t:P:vV',
                 ['connection=', 'debug', 'doctype=', 'export=', 'field=', 'format=',
                  'help', 'import=', 'listener', 'meta=', 'no-launch', 'output=',
                  'outputpath', 'password=', 'pipe=', 'port=', 'preserve',
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
-                 'verbose', 'version'] )
+                 'verbose', 'version'])
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
@@ -568,14 +578,14 @@ class Options:
                     if name in ('FilterOptions'):
                         self.exportfilteroptions = value
                     elif value in ('True', 'true'):
-                        self.exportfilter.append( PropertyValue( name, 0, True, 0 ) )
+                        self.exportfilter.append(PropertyValue(name, 0, True, 0))
                     elif value in ('False', 'false'):
-                        self.exportfilter.append( PropertyValue( name, 0, False, 0 ) )
+                        self.exportfilter.append(PropertyValue(name, 0, False, 0))
                     else:
                         try:
-                            self.exportfilter.append( PropertyValue( name, 0, int(value), 0 ) )
+                            self.exportfilter.append(PropertyValue(name, 0, int(value), 0))
                         except ValueError:
-                            self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
+                            self.exportfilter.append(PropertyValue(name, 0, value, 0))
                 else:
                     print('Warning: Option %s cannot be parsed, ignoring.' % arg, file=sys.stderr)
             elif opt in ['-F', '--field']:
@@ -590,14 +600,14 @@ class Options:
                     if name in ('FilterOptions'):
                         self.importfilteroptions = value
                     elif value in ('True', 'true'):
-                        self.importfilter.append( PropertyValue( name, 0, True, 0 ) )
+                        self.importfilter.append(PropertyValue(name, 0, True, 0))
                     elif value in ('False', 'false'):
-                        self.importfilter.append( PropertyValue( name, 0, False, 0 ) )
+                        self.importfilter.append(PropertyValue(name, 0, False, 0))
                     else:
                         try:
-                            self.importfilter.append( PropertyValue( name, 0, int(value), 0 ) )
+                            self.importfilter.append(PropertyValue(name, 0, int(value), 0))
                         except ValueError:
-                            self.importfilter.append( PropertyValue( name, 0, value, 0 ) )
+                            self.importfilter.append(PropertyValue(name, 0, value, 0))
                 else:
                     print('Warning: Option %s cannot be parsed, ignoring.' % arg, file=sys.stderr)
             elif opt in ['-l', '--listener']:
@@ -647,7 +657,7 @@ class Options:
                     self.setprinter = True
                 elif optKey in ['PaperSize']:
                     intFunc = int if sys.version_info.major > 2 else long
-                    size =  list(map(lambda s: intFunc(s), optValue.split('x')))
+                    size = list(map(lambda s: intFunc(s), optValue.split('x')))
                     if (2 == len(size)):
                         self.papersize = size
                         self.setprinter = True
@@ -754,6 +764,7 @@ unoconv options:
                                           eg. -P PaperSize=130x200 means width=130, height=200
 ''', file=sys.stderr)
 
+
 class Convertor:
     def __init__(self):
         global exitcode, ooproc, office, product
@@ -774,7 +785,7 @@ class Convertor:
         ### And some more LibreOffice magic
         unosvcmgr = unocontext.ServiceManager
         self.desktop = unosvcmgr.createInstanceWithContext("com.sun.star.frame.Desktop", unocontext)
-        self.cwd = unohelper.systemPathToFileUrl( os.getcwd() )
+        self.cwd = unohelper.systemPathToFileUrl(os.getcwd())
 
         ### List all filters
 #        self.filters = unosvcmgr.createInstanceWithContext( "com.sun.star.document.FilterFactory", unocontext)
@@ -789,7 +800,7 @@ class Convertor:
         try:
             unocontext = resolver.resolve("uno:%s" % op.connection)
         except NoConnectException as e:
-#            info(3, "Existing listener not found.\n%s" % e)
+            # info(3, "Existing listener not found.\n%s" % e)
             info(3, "Existing listener not found.")
 
             if op.nolaunch:
@@ -815,7 +826,7 @@ class Convertor:
                         return self.connect(resolver)
                         break
 
-                    elif retcode != None:
+                    elif retcode is not None:
                         info(3, "Process %s (pid=%s) exited with %s." % (office.binary, ooproc.pid, retcode))
                         break
 
@@ -910,12 +921,12 @@ class Convertor:
 
             ### Cannot use UnoProps for FilterData property
             if op.importfilteroptions:
-#                print "Import filter options: %s" % op.importfilteroptions
+                # print "Import filter options: %s" % op.importfilteroptions
                 inputprops += UnoProps(FilterOptions=op.importfilteroptions)
 
             ### Cannot use UnoProps for FilterData property
             if op.importfilter:
-                inputprops += ( PropertyValue( "FilterData", 0, uno.Any("[]com.sun.star.beans.PropertyValue", tuple( op.importfilter ), ), 0 ), )
+                inputprops += (PropertyValue("FilterData", 0, uno.Any("[]com.sun.star.beans.PropertyValue", tuple(op.importfilter),), 0),)
 
             if op.stdin:
                 inputStream = self.svcmgr.createInstanceWithContext("com.sun.star.io.SequenceInputStream", self.context)
@@ -927,7 +938,7 @@ class Convertor:
                     inputurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(inputfn))
                 else:
                     inputurl = inputfn
-            document = self.desktop.loadComponentFromURL( inputurl , "_blank", 0, inputprops )
+            document = self.desktop.loadComponentFromURL(inputurl, "_blank", 0, inputprops)
 
             if not document:
                 raise UnoException("The document '%s' could not be opened." % inputurl, None)
@@ -956,16 +967,16 @@ class Convertor:
             phase = "update-links"
             try:
                 document.updateLinks()
-                # Found that when converting HTML files with external images, OO would only load five or six of 
-                # the images in the file. In the resulting document, the rest of the images did not appear. Cycling 
-                # through all the image references in the document seems to force OO to actually load them. Found 
+                # Found that when converting HTML files with external images, OO would only load five or six of
+                # the images in the file. In the resulting document, the rest of the images did not appear. Cycling
+                # through all the image references in the document seems to force OO to actually load them. Found
                 # some helpful guidance in this thread:
                 # https://forum.openoffice.org/en/forum/viewtopic.php?f=30&t=23909
                 # Ideally we would like to have the option to embed the images into the document, but I have not been
                 # able to figure out how to do this yet.
                 graphObjs = document.GraphicObjects
                 for i in range(0, graphObjs.getCount()):
-                    graphObj = graphObjs.getByIndex(i)
+                    graphObjs.getByIndex(i)
             except AttributeError:
                 # the document doesn't implement the XLinkUpdate interface
                 pass
@@ -973,19 +984,19 @@ class Convertor:
             ### Add/Replace variables
             phase = "replace-fields"
             for f in op.fields:
-              try:
-                field = document.TextFieldMasters.getByName("com.sun.star.text.fieldmaster.SetExpression.%s" % f)
-                field.DependentTextFields[0].setPropertyValue('Content', op.fields[f])
-              except UnoException as e:
-                error("unoconv: failed to replace variable '%s' with value '%s' in the document." % (f, op.fields[f]))
-                pass
+                try:
+                    field = document.TextFieldMasters.getByName("com.sun.star.text.fieldmaster.SetExpression.%s" % f)
+                    field.DependentTextFields[0].setPropertyValue('Content', op.fields[f])
+                except UnoException as e:
+                    error("unoconv: failed to replace variable '%s' with value '%s' in the document." % (f, op.fields[f]))
+                    pass
 
             ### Add/Replace metadata
             phase = "replace-metadata"
             props = document.getDocumentProperties()
             user_props = props.getUserDefinedProperties()
             for prop, value in op.metadata.items():
-                for container in ( props, user_props ):
+                for container in (props, user_props):
                     curr = getattr(container, prop, None)
                     if curr is not None:
                         setattr(container, prop, value)
@@ -1029,7 +1040,7 @@ class Convertor:
 
             ### Set default filter options
             if op.exportfilteroptions:
-#                print "Export filter options: %s" % op.exportfilteroptions
+                # print "Export filter options: %s" % op.exportfilteroptions
                 outputprops += UnoProps(FilterOptions=op.exportfilteroptions)
             else:
                 if outputfmt.filter == 'Text (encoded)':
@@ -1056,7 +1067,7 @@ class Convertor:
 
             ### Cannot use UnoProps for FilterData property
             if op.exportfilter:
-                outputprops += ( PropertyValue( "FilterData", 0, uno.Any("[]com.sun.star.beans.PropertyValue", tuple( op.exportfilter ), ), 0 ), )
+                outputprops += (PropertyValue("FilterData", 0, uno.Any("[]com.sun.star.beans.PropertyValue", tuple(op.exportfilter),), 0),)
 
             if op.stdout:
                 ### Ensure binary data to stdout works
@@ -1079,12 +1090,12 @@ class Convertor:
                 else:
                     outputfn = realpath(inbase + os.extsep + outputfmt.extension)
 
-                outputurl = unohelper.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
+                outputurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(outputfn))
 
             info(1, "Output file: %s" % outputurl)
 
             try:
-                document.storeToURL(outputurl, tuple(outputprops) )
+                document.storeToURL(outputurl, tuple(outputprops))
             except IOException as e:
                 raise UnoException("Unable to store document to %s (ErrCode %d)\n\nProperties: %s" % (outputurl, e.ErrCode, outputprops), None)
 
@@ -1111,12 +1122,12 @@ class Convertor:
             exitcode = 8
 
         except IOException as e:
-#            for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
+            # for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
             error("unoconv: IOException during %s phase:\n%s" % (phase, e.Message))
             exitcode = 3
 
         except CannotConvertException as e:
-#            for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
+            # for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
             error("unoconv: CannotConvertException during %s phase:\n%s" % (phase, e.Message))
             exitcode = 4
 
@@ -1133,6 +1144,7 @@ class Convertor:
                 exitcode = 2
                 pass
 
+
 class Listener:
     def __init__(self):
         global product
@@ -1144,7 +1156,7 @@ class Listener:
             resolver = self.svcmgr.createInstanceWithContext("com.sun.star.bridge.UnoUrlResolver", self.context)
             product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
             try:
-                unocontext = resolver.resolve("uno:%s" % op.connection)
+                resolver.resolve("uno:%s" % op.connection)
             except NoConnectException as e:
                 pass
             else:
@@ -1159,9 +1171,11 @@ class Listener:
         else:
             info(1, "Existing %s listener found, nothing to do." % product.ooName)
 
+
 def error(msg):
     "Output error message"
     print(msg, file=sys.stderr)
+
 
 def info(level, msg):
     "Output info message"
@@ -1173,6 +1187,7 @@ def info(level, msg):
         print(msg, file=sys.stdout)
     elif level <= op.verbose:
         print(msg, file=sys.stderr)
+
 
 def die(ret, msg=None):
     "Print optional error and exit with errorcode"
@@ -1213,7 +1228,7 @@ def die(ret, msg=None):
 
         ### LibreOffice processes may get stuck and we have to kill them
         ### Is it still running ?
-        if ooproc.poll() == None:
+        if ooproc.poll() is None:
             info(1, '%s instance still running, please investigate...' % product.ooName)
             ooproc.wait()
             info(2, '%s instance unsuccessfully terminated, sending KILL signal.' % product.ooName)
@@ -1230,13 +1245,14 @@ def die(ret, msg=None):
 
     sys.exit(ret)
 
+
 def main():
     global convertor, exitcode
     convertor = None
 
     try:
         if op.listener:
-            listener = Listener()
+            Listener()
 
         if op.stdin:
             inputfn = sys.stdin.read()
@@ -1247,7 +1263,7 @@ def main():
             for inputfn in op.filenames:
                 convertor.convert(inputfn)
 
-    except NoConnectException as e:
+    except NoConnectException:
         error("unoconv: could not find an existing connection to LibreOffice at %s:%s." % (op.server, op.port))
         if op.connection:
             info(0, "Please start an LibreOffice instance on server '%s' by doing:\n\n    unoconv --listener --server %s --port %s\n\nor alternatively:\n\n    soffice -nologo -nodefault -accept=\"%s\"" % (op.server, op.server, op.port, op.connection))
@@ -1272,16 +1288,17 @@ if __name__ == '__main__':
         office_environ(of)
 #        debug_office()
         try:
-            import uno, unohelper
+            import uno
+            import unohelper
             office = of
             break
         except:
-#            debug_office()
+            # debug_office()
             print("unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of, file=sys.stderr)
             print("ERROR:", sys.exc_info()[1], file=sys.stderr)
             print(file=sys.stderr)
     else:
-#        debug_office()
+        # debug_office()
         print("unoconv: Cannot find a suitable office installation on your system.", file=sys.stderr)
         print("ERROR: Please locate your office installation and send your feedback to:", file=sys.stderr)
         print("       http://github.com/dagwieers/unoconv/issues", file=sys.stderr)
@@ -1298,20 +1315,20 @@ if __name__ == '__main__':
     from com.sun.star.uno import RuntimeException
 
     ### And now that we have those classes, build on them
-    class OutputStream( unohelper.Base, XOutputStream ):
-        def __init__( self ):
+    class OutputStream(unohelper.Base, XOutputStream):
+        def __init__(self):
             self.closed = 0
 
         def closeOutput(self):
             self.closed = 1
 
-        def writeBytes( self, seq ):
+        def writeBytes(self, seq):
             try:
-                sys.stdout.buffer.write( seq.value )
+                sys.stdout.buffer.write(seq.value)
             except AttributeError:
-                sys.stdout.write( seq.value )
+                sys.stdout.write(seq.value)
 
-        def flush( self ):
+        def flush(self):
             pass
 
     def UnoProps(**args):


### PR DESCRIPTION
Hello Dag Wieers,

You don't seem to be opposed to PEP 8 changes (did not see a single issue or pull request mentioning this), so I thought this pull request could be helpful. I believe that codebases that follow PEP 8 are easier to read simply because they are more consistent with other Python code.

This does not fix all issues, but fixes most of them. It currently ignores (see the tox.ini file):
  * E262 (inline comment should start with ‘#‘)
  * E265 (block comment should start with ‘#‘)
  * E501 (line too long (82 > 79 characters))
  * F821 (undefined name)

If you think the pull request is too big, I can split it in several parts. If there are some PEP 8 errors that you don't want to fix, I can remove the fixes too. To test the pull request, you can run "flake8 unoconv".

Thank you for unoconv.