### PR TITLE
Change the shebang to Python 3

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ### This program is free software; you can redistribute it and/or modify
 ### it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
According to #290, unoconv 0.7 is broken on Python 2 / Ubuntu 14.04 and the fix is to ask for Python 3. If you want to support Python 2, I can try to look into what's going on.