### PR TITLE
Add .travis.yml to run tests on 4.5 and 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python:
+  - "3.4"
+
+env:
+  - VERSION=4.4.5
+  - VERSION=5.0.1
+
+before_install:
+  - pushd /tmp
+  - wget http://download.documentfoundation.org/libreoffice/stable/${VERSION}/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
+  - tar xvf LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
+  - cd LibreOffice_${VERSION}.?_Linux_x86-64_deb/DEBS
+  - sudo dpkg -i *.deb
+  - popd
+
+script:
+  - cd tests
+  - make

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,11 @@
 ### Please modify and send me improvements
 
-python=/opt/libreoffice4.4/program/python
+twodigitsversion=$(shell echo $$VERSION | cut -c 1-3)
+python=/opt/libreoffice$(twodigitsversion)/program/python
 unoconv=../unoconv
 
-all: clean doc6 doc95 doc docbook fodt html mediawiki ooxml pdf rtf sdw3 sdw4 sdw sxw text txt uot xhtml
+# failing filters doc6 doc95 sdw3 sdw4 sdw sxw
+all: clean doc docbook fodt html mediawiki ooxml pdf rtf text txt uot xhtml
 	@echo "== Tests finished."
 
 #xml: curriculum-vitae-dag-wieers.txt
@@ -16,7 +18,7 @@ all: clean doc6 doc95 doc docbook fodt html mediawiki ooxml pdf rtf sdw3 sdw4 sd
 %:
 #	-killall ooffice soffice.bin
 	@echo "- Convert document-example.odt to $@..."
-	-$(python) $(unoconv) -vvv -p 2002 -f $@ document-example.odt
+	$(python) $(unoconv) -vvv -p 2002 -f $@ document-example.odt
 	@echo
 #	@ps aux | grep office
 #	-unoconv -f $@ dag.gif


### PR DESCRIPTION
This is only one commit, but it's the result of much trial and error on my fork. Here's how this looks in Travis: https://travis-ci.org/pquentin/unoconv/builds/79417454. You'll have to sign up on Travis to get automatic builds for commits and pull requests.

This only tests 4.5 and 5.0 on Linux and I removed some failing tests, but I hope you'll consider this as a good starting point.