### PR TITLE
Add .travis.yml to run tests from 3.3 to 5.0 on OS X and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
-language: python
-
-python:
-  - "3.4"
 
 env:
+  - VERSION=3.3.4.1
+  - VERSION=3.4.6.2
+  - VERSION=3.5.7.2
+  - VERSION=3.6.7.2
+  - VERSION=4.0.6.2
+  - VERSION=4.1.6.1
+  - VERSION=4.2.8.2
+  - VERSION=4.3.7.2
   - VERSION=4.4.5
   - VERSION=5.0.1
 
+matrix:
+  allow_failures:
+    - os: linux
+      env: VERSION=3.3.4.1
+
 before_install:
-  - pushd /tmp
-  - wget http://download.documentfoundation.org/libreoffice/stable/${VERSION}/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
-  - tar xvf LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
-  - cd LibreOffice_${VERSION}.?_Linux_x86-64_deb/DEBS
-  - sudo dpkg -i *.deb
-  - popd
+  - sudo VERSION=$VERSION bash ci/linux.bash
 
 script:
   - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+
+python:
+  - "3.4"
+
+env:
+  - VERSION=4.4.5
+  - VERSION=5.0.1
+
+before_install:
+  - pushd /tmp
+  - wget http://download.documentfoundation.org/libreoffice/stable/${VERSION}/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
+  - tar xvf LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz
+  - cd LibreOffice_${VERSION}.?_Linux_x86-64_deb/DEBS
+  - sudo dpkg -i *.deb
+  - popd
+
+script:
+  - cd tests
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - osx
 
 env:
   - VERSION=3.3.4.1
@@ -13,11 +16,20 @@ env:
 
 matrix:
   allow_failures:
+    - os: osx
     - os: linux
       env: VERSION=3.3.4.1
+  exclude:
+    - os: osx
+      env: VERSION=3.3.4.1
+    - os: osx
+      env: VERSION=3.4.6.2
+    - os: osx
+      env: VERSION=3.5.7.2
 
 before_install:
   - sudo VERSION=$VERSION bash ci/linux.bash
+  - sudo VERSION=$VERSION bash ci/osx.bash
 
 script:
   - cd tests

--- a/ci/linux.bash
+++ b/ci/linux.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit
+
+[[ $(uname) != 'Linux' ]] && exit
+
+pushd /tmp
+
+if [[ "$VERSION" =~ ^3.3.* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
+    cutversion=$(echo $VERSION | sed 's/\.[0-9]$//')
+    filename=LibO_${cutversion}_Linux_x86-64_install-deb_en-US
+elif [[ "$VERSION" =~ ^3.[4-5].* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
+    rcversion=$(echo $VERSION | sed 's/\.2$/rc2/')
+    filename=LibO_${rcversion}_Linux_x86-64_install-deb_en-US
+elif [[ "$VERSION" =~ ^3.* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
+    filename=LibO_${VERSION}_Linux_x86-64_install-deb_en-US
+elif [[ "$VERSION" =~ ^4.[0-3].* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
+    filename=LibreOffice_${VERSION}_Linux_x86-64_deb
+else
+    urldir=http://download.documentfoundation.org/libreoffice/stable/$VERSION/deb/x86_64/
+    filename=LibreOffice_${VERSION}_Linux_x86-64_deb
+fi
+
+wget $urldir/${filename}.tar.gz
+tar xvf ${filename}.tar.gz
+dpkg -i Lib*_Linux_x86-64*deb*/DEBS/*.deb
+
+twodigitsversion=$(echo $VERSION | cut -c 1-3)
+ln -s /opt/libreoffice${twodigitsversion}/program/python /tmp/python

--- a/ci/osx.bash
+++ b/ci/osx.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+
+[[ $(uname) != 'Darwin' ]] && exit
+
+pushd /tmp
+
+if [[ "$VERSION" =~ ^3.6.* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/mac/x86
+    filename=LibO_${VERSION}_MacOS_x86_install_en-US.dmg
+elif [[ "$VERSION" =~ ^4.[0-1].* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/mac/x86
+    filename=LibreOffice_${VERSION}_MacOS_x86.dmg
+elif [[ "$VERSION" =~ ^4.[2-3].* ]]; then
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/mac/x86_64
+    filename=LibreOffice_${VERSION}_MacOS_x86-64.dmg
+else
+    urldir=https://download.documentfoundation.org/libreoffice/stable/$VERSION/mac/x86_64
+    filename=LibreOffice_${VERSION}_MacOS_x86-64.dmg
+fi
+
+wget $urldir/$filename
+sudo hdiutil attach $filename
+
+ln -s /Volumes/LibreOffice/LibreOffice.app/Contents/MacOS/python /tmp/python

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,6 @@
 ### Please modify and send me improvements
 
-twodigitsversion=$(shell echo $$VERSION | cut -c 1-3)
-python=/opt/libreoffice$(twodigitsversion)/program/python
+python=/tmp/python
 unoconv=../unoconv
 
 # failing filters doc6 doc95 sdw3 sdw4 sdw sxw

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,11 @@
 ### Please modify and send me improvements
 
-python=/opt/libreoffice4.4/program/python
+twodigitsversion=$(shell echo $$VERSION | cut -c 1-3)
+python=/opt/libreoffice$(twodigitsversion)/program/python
 unoconv=../unoconv
 
-all: clean doc6 doc95 doc docbook fodt html mediawiki ooxml pdf rtf sdw3 sdw4 sdw sxw text txt uot xhtml
+# failing filters doc6 doc95 sdw3 sdw4 sdw sxw
+all: clean doc docbook fodt html mediawiki ooxml pdf rtf text txt uot xhtml
 	@echo "== Tests finished."
 
 #xml: curriculum-vitae-dag-wieers.txt
@@ -16,7 +18,7 @@ all: clean doc6 doc95 doc docbook fodt html mediawiki ooxml pdf rtf sdw3 sdw4 sd
 %:
 #	-killall ooffice soffice.bin
 	@echo "- Convert document-example.odt to $@..."
-	-$(python) $(unoconv) -vvv -p 2002 -f $@ document-example.odt
+	$(python) $(unoconv) -vvv -p 2002 -f $@ document-example.odt
 	@echo
 #	@ps aux | grep office
 #	-unoconv -f $@ dag.gif


### PR DESCRIPTION
This is an extended version of pull request #295 which adds more LibreOffice versions and extends the tests to OS X. I did not close #295 yet in case you want to keep it instead. Here's the Travis output for this pull request: https://travis-ci.org/pquentin/unoconv/builds/79622720.

For some reason, the tests on OS X don't pass. They're still valuable because they highlight the regression from #292: starting from 4.4, environment is not correctly detected.

I've discussed with @nthiebaud on #tdf-infra who kindly offered to host the continuous integration on a TDF server, which would:
 1. make tests much faster since the files would be hosted locally
 2. allow to test the master branch to detect issues early
 3. prevent hitting the servers too hard.

However, it would be more work to setup and maintain, so starting with Travis might be wiser.

Also, which versions do you want to support? Going back to 3.3 is maybe too much.