### PR TITLE
allow unoconv be imported as a python module and also allow call unoc…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+from setuptools import setup
+unoconv = __import__("unoconv")
+
+setup(
+	name="unoconv",
+	version=unoconv.__version__,
+	py_modules=["unoconv"],
+	entry_points={
+        'console_scripts': [
+            'unoconv = unoconv:run_unoconv'
+            ]
+        }
+    )

--- a/unoconv
+++ b/unoconv
@@ -1260,8 +1260,7 @@ def main():
     except OSError:
         error("Warning: failed to launch Office suite. Aborting.")
 
-### Main entrance
-if __name__ == '__main__':
+def run_unoconv():
     exitcode = 0
 
     info(3, 'sysname=%s, platform=%s, python=%s, python-version=%s' % (os.name, sys.platform, sys.executable, sys.version))
@@ -1333,3 +1332,8 @@ if __name__ == '__main__':
     except KeyboardInterrupt as e:
         die(6, 'Exiting on user request')
     die(exitcode)
+
+
+### Main entrance
+if __name__ == '__main__':
+    run_unoconv()


### PR DESCRIPTION
I made a setup.py that allows unoconv be imported as a python module without lose the functionality of call `unoconv`.

The setup.py is small and doesn't solve all the problems, but it's a begin.
