### PR TITLE
Fix travis downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   - VERSION=4.1.6.1
   - VERSION=4.2.8.2
   - VERSION=4.3.7.2
-  - VERSION=4.4.5
-  - VERSION=5.0.1
+  - VERSION=4.4.7.2
+  - VERSION=5.0.4.2
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - VERSION=4.3.7.2
   - VERSION=4.4.7.2
   - VERSION=5.0.4.2
+  - VERSION=5.1.0.2
 
 matrix:
   allow_failures:

--- a/ci/linux.bash
+++ b/ci/linux.bash
@@ -17,11 +17,8 @@ elif [[ "$VERSION" =~ ^3.[4-5].* ]]; then
 elif [[ "$VERSION" =~ ^3.* ]]; then
     urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
     filename=LibO_${VERSION}_Linux_x86-64_install-deb_en-US
-elif [[ "$VERSION" =~ ^4.[0-3].* ]]; then
-    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
-    filename=LibreOffice_${VERSION}_Linux_x86-64_deb
 else
-    urldir=http://download.documentfoundation.org/libreoffice/stable/$VERSION/deb/x86_64/
+    urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/deb/x86_64
     filename=LibreOffice_${VERSION}_Linux_x86-64_deb
 fi
 

--- a/ci/osx.bash
+++ b/ci/osx.bash
@@ -12,12 +12,10 @@ if [[ "$VERSION" =~ ^3.6.* ]]; then
 elif [[ "$VERSION" =~ ^4.[0-1].* ]]; then
     urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/mac/x86
     filename=LibreOffice_${VERSION}_MacOS_x86.dmg
-elif [[ "$VERSION" =~ ^4.[2-3].* ]]; then
+else
     urldir=https://downloadarchive.documentfoundation.org/libreoffice/old/$VERSION/mac/x86_64
     filename=LibreOffice_${VERSION}_MacOS_x86-64.dmg
 else
-    urldir=https://download.documentfoundation.org/libreoffice/stable/$VERSION/mac/x86_64
-    filename=LibreOffice_${VERSION}_MacOS_x86-64.dmg
 fi
 
 wget $urldir/$filename


### PR DESCRIPTION
It turns out that download.documentfoundation.org links get stale very quickly, so always using downloadarchive.documentfoundation.org will ensure the links won't break. 