### PR TITLE
Drop support for v3.3 and v3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - osx
 
 env:
-  - VERSION=3.3.4.1
-  - VERSION=3.4.6.2
   - VERSION=3.5.7.2
   - VERSION=3.6.7.2
   - VERSION=4.0.6.2
@@ -20,13 +18,8 @@ matrix:
   allow_failures:
     - os: osx
     - os: linux
-      env: VERSION=3.3.4.1
     - env: VERSION=5.1.2.1
   exclude:
-    - os: osx
-      env: VERSION=3.3.4.1
-    - os: osx
-      env: VERSION=3.4.6.2
     - os: osx
       env: VERSION=3.5.7.2
 

--- a/unoconv
+++ b/unoconv
@@ -1271,12 +1271,12 @@ def main():
             listener = Listener()
 
         if op.stdin:
-        	### Read stdin buffer in Python 3 in order to correctly handle binary streams
-        	### ref: https://docs.python.org/3.1/library/sys.html#sys.stdin
+            ### Read stdin buffer in Python 3 in order to correctly handle binary streams
+            ### ref: https://docs.python.org/3.1/library/sys.html#sys.stdin
             if sys.version_info.major > 2:
                 inputfn = sys.stdin.buffer.read()
             else:
-            	inputfn = sys.stdin.read()
+                inputfn = sys.stdin.read()
             convertor = Convertor()
             convertor.convert(inputfn)
         elif op.filenames:


### PR DESCRIPTION
Tests won't run for 3.3 and 3.4. 3.4 for example refuses to run as --headless. 3.3 and 3.4 are over 5 years old, I suggest we drop support for them.