### PR TITLE
All tests fail on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-  - osx
+#  - osx
 
 env:
   - VERSION=3.5.7.2


### PR DESCRIPTION
Disable those tests temporarily, as running them is pointless until somebody can fix the tests.