### PR TITLE
Added in password support

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -935,6 +935,9 @@ class Convertor:
 #            if op.password:
 #                info = UnoProps(algorithm-name="PBKDF2", salt="salt", iteration-count=1024, hash="hash")
 #                inputprops += UnoProps(ModifyPasswordInfo=info)
+            if op.password:
+                print("decrypting file with password: " + op.password)
+                inputprops += UnoProps(Password=op.password)
 
             ### Cannot use UnoProps for FilterData property
             if op.importfilteroptions:

--- a/unoconv
+++ b/unoconv
@@ -936,7 +936,8 @@ class Convertor:
 #                info = UnoProps(algorithm-name="PBKDF2", salt="salt", iteration-count=1024, hash="hash")
 #                inputprops += UnoProps(ModifyPasswordInfo=info)
             if op.password:
-                print("decrypting file with password: " + op.password)
+                if op.verbose > 0:
+                    print("decrypting file with password: " + op.password)
                 inputprops += UnoProps(Password=op.password)
 
             ### Cannot use UnoProps for FilterData property


### PR DESCRIPTION
Unoconv documentation claims support for decryption of files. Although there was a place to enter the password, any use of that password was commented out in the source code. Upon researching, it was discovered that the only thing that the listener needed was to have that password passed on to it. I added in the lines of code required to enable this functionality.